### PR TITLE
Role identity (M1): Parent vs Organizer separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 __pycache__/
 *.pyc
 .venv/
+.superpowers/

--- a/docs/superpowers/plans/2026-04-15-role-identity-and-trust.md
+++ b/docs/superpowers/plans/2026-04-15-role-identity-and-trust.md
@@ -1,0 +1,2175 @@
+# Role Identity & Trust Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Kiddaboo a strong role identity (Parent vs Organizer) and strong user identity (real name + phone verification + trust signals), structured so the work carries over verbatim to the WelbyRise reskin.
+
+**Architecture:** One `profiles.account_type` column drives two mode layouts (`ParentLayout` / `OrganizerLayout`) that differ in accent color, mode label, and bottom nav. URLs stay as-is; a `<RequireRole>` guard redirects cross-mode access. A new `ChooseRole` signup page forces new users to pick a role before anything else. Phone OTP is the single verification mechanism; a Supabase edge function pair (`send-otp` / `verify-otp`) talks to Twilio. The `ProfilePanel` component is restructured around a fixed set of v1 trust signals.
+
+**Tech Stack:** React 18.2 + Vite 4.4 + React Router v6 + Tailwind 3.4 + Supabase (Postgres + Edge Functions) + Twilio Verify + Stripe. Test harness: Vitest 4 + @testing-library/react + jsdom (already installed). No Playwright in v1 — manual e2e only.
+
+**Milestone structure:** Three independently shippable milestones.
+- **M1 — Role identity core** (Tasks 1–12). Migration, `account_type`, layouts, signup path picker, copy rename. Ships perceptual role separation.
+- **M2 — Phone OTP verification** (Tasks 13–19). New tables, edge functions, onboarding step, verified badge data.
+- **M3 — Profile panel trust redesign** (Tasks 20–25). Restructured `ProfilePanel` + unified playgroup detail member list + badge components.
+
+Each milestone ends in a deployable state. Do not start M2 until M1 is merged. Do not start M3 until M2 is merged.
+
+---
+
+## File Structure
+
+### New files
+- `supabase/migrations/20260416000001_add_account_type.sql` — profiles.account_type column + backfill
+- `supabase/migrations/20260416000002_add_phone_verification.sql` — phone columns + phone_otp_challenges table (M2)
+- `frontend/src/layouts/ParentLayout.jsx` — sage accent, Parent bottom nav, "PARENT" mode label
+- `frontend/src/layouts/OrganizerLayout.jsx` — terracotta accent, Organizer bottom nav
+- `frontend/src/layouts/SharedLayout.jsx` — for /my-profile, /premium, /admin
+- `frontend/src/components/auth/RequireRole.jsx` — redirects users on the wrong-role route
+- `frontend/src/pages/onboarding/ChooseRole.jsx` — two-card role picker landing
+- `frontend/src/pages/onboarding/PhoneVerify.jsx` — OTP step (M2)
+- `frontend/src/hooks/useAccountType.js` — thin accessor over `profile.account_type`
+- `frontend/src/hooks/usePhoneVerification.js` — OTP send/verify (M2)
+- `frontend/src/components/profile/ProfilePanel.jsx` — redesigned trust panel (M3)
+- `frontend/src/components/profile/VerifiedBadge.jsx` — green check overlay (M3)
+- `frontend/src/components/profile/RoleBadge.jsx` — Organizer/Parent pill (M3)
+- `supabase/functions/send-otp/index.ts` — Twilio send (M2)
+- `supabase/functions/verify-otp/index.ts` — code validation (M2)
+- Tests (one per above component/hook/function under matching `__tests__/` or co-located `.test.js(x)` files)
+
+### Modified files
+- `frontend/src/context/AuthContext.jsx` — expose `accountType`, remove `isHost` membership query (still compute for back-compat until callers migrated)
+- `frontend/src/components/layout/TabBar.jsx` — switch from `isHost` to `accountType`
+- `frontend/src/App.jsx` — wrap routes in role-specific layouts + `<RequireRole>` gates
+- `frontend/src/pages/Welcome.jsx` — reroute to `/choose-role` instead of `/verify` when no `account_type`
+- `frontend/src/pages/MyProfile.jsx` — rename "Host Premium" → "Organizer Premium"
+- `frontend/src/pages/Browse.jsx` — "Host a Playgroup" → "Organize a Playgroup"
+- `frontend/src/pages/MyGroups.jsx` — same
+- `frontend/src/pages/host/HostDashboard.jsx` — "Host a Playgroup" → "Organize a Playgroup", "Go Host Premium" → "Go Organizer Premium"
+- `frontend/src/pages/host/HostInsights.jsx` — same
+- `frontend/src/pages/host/HostPremium.jsx` — all "Host Premium" → "Organizer Premium"
+- `frontend/src/pages/admin/SubscriptionsTab.jsx` — "Host Premium" label → "Organizer Premium"
+- `frontend/src/pages/PlaygroupDetail.jsx` — use unified member list + RoleBadge (M3)
+- `supabase/config.toml` — register new edge functions (M2)
+- `frontend/src/test/regression.test.jsx` — update expectation to "Organize a Playgroup"
+
+### Files that keep DB identifiers (DO NOT RENAME)
+- `memberships.role = 'creator'` — DB value stays
+- `subscriptions.type = 'host_premium'` — DB value stays
+- `subscriptions.plan` prefixes (`host_monthly`, `host_annual`) — stay
+- Edge function names that reference "host" — stay unless specifically listed above
+- Route paths (`/host/dashboard`, `/host/premium`, `/host/create`, ...) — stay in v1
+
+Reasoning: a rename at the DB/URL level is a much riskier change with no user-visible benefit. The user sees "Organizer" everywhere; the code continues to call it `host`/`creator` internally.
+
+---
+
+# M1 — Role Identity Core
+
+## Task 1: Migration for `profiles.account_type`
+
+**Files:**
+- Create: `supabase/migrations/20260416000001_add_account_type.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 20260416000001_add_account_type.sql
+-- Adds profiles.account_type so we can distinguish Parent vs Organizer
+-- users without the expensive memberships.role='creator' lookup every
+-- AuthContext fetch does today.
+
+ALTER TABLE profiles
+  ADD COLUMN account_type TEXT
+  CHECK (account_type IN ('parent', 'organizer'))
+  NOT NULL DEFAULT 'parent';
+
+-- Backfill: anyone who has ever been a group creator is an organizer.
+-- Everyone else stays 'parent' (the default).
+UPDATE profiles p
+SET account_type = 'organizer'
+WHERE EXISTS (
+  SELECT 1
+  FROM memberships m
+  WHERE m.user_id = p.id
+    AND m.role = 'creator'
+);
+
+-- Drop the default so new signups MUST pick a role explicitly via the
+-- ChooseRole path picker. Any insert that omits account_type will now
+-- error, which is what we want.
+ALTER TABLE profiles ALTER COLUMN account_type DROP DEFAULT;
+
+-- Index — we'll filter by account_type in admin views and usage stats.
+CREATE INDEX IF NOT EXISTS profiles_account_type_idx
+  ON profiles (account_type);
+```
+
+- [ ] **Step 2: Apply the migration**
+
+Run: `cd /Users/sureshkumar/Kiddaboo && supabase db push`
+Expected: migration applied cleanly; `\d profiles` shows the new column.
+
+- [ ] **Step 3: Verify the backfill with a spot check**
+
+Run from the Supabase SQL editor:
+```sql
+SELECT account_type, count(*) FROM profiles GROUP BY account_type;
+```
+Expected: `organizer` count equals the number of distinct `memberships.user_id` with `role='creator'`. `parent` count is everyone else.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260416000001_add_account_type.sql
+git commit -m "feat: add profiles.account_type column + backfill existing creators"
+```
+
+---
+
+## Task 2: AuthContext exposes `accountType`
+
+**Files:**
+- Modify: `frontend/src/context/AuthContext.jsx`
+- Test: `frontend/src/context/AuthContext.test.jsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/context/AuthContext.test.jsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./AuthContext";
+import { supabase } from "../lib/supabase";
+import { vi } from "vitest";
+
+vi.mock("../lib/supabase");
+
+function Probe() {
+  const { accountType, loading } = useAuth();
+  return <div>type={loading ? "…" : accountType ?? "null"}</div>;
+}
+
+test("AuthContext exposes accountType from the profiles row", async () => {
+  supabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "u1" } } },
+  });
+  supabase.auth.onAuthStateChange.mockReturnValue({
+    data: { subscription: { unsubscribe: vi.fn() } },
+  });
+  supabase.from.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        single: () => Promise.resolve({ data: { id: "u1", first_name: "A", account_type: "organizer" }, error: null }),
+        limit: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
+  });
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  await waitFor(() => expect(screen.getByText("type=organizer")).toBeInTheDocument());
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sureshkumar/Kiddaboo/frontend && npm test -- AuthContext`
+Expected: FAIL — `accountType` is undefined.
+
+- [ ] **Step 3: Update AuthContext**
+
+Edit `frontend/src/context/AuthContext.jsx`:
+
+Replace the `select` in `fetchProfile` (line 46) to add `account_type`:
+
+```js
+.select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role, account_type")
+```
+
+Replace the same `select` in `updateProfile` (line 111) the same way.
+
+In the provider value (line 127), add `accountType: profile?.account_type ?? null`:
+
+```jsx
+<AuthContext.Provider
+  value={{
+    user,
+    profile,
+    loading,
+    isAdmin,
+    isHost,
+    accountType: profile?.account_type ?? null,
+    refreshHostStatus,
+    signUp,
+    signIn,
+    signOut,
+    updateProfile,
+    fetchProfile,
+  }}
+>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/sureshkumar/Kiddaboo/frontend && npm test -- AuthContext`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/context/AuthContext.jsx frontend/src/context/AuthContext.test.jsx
+git commit -m "feat: expose accountType from AuthContext"
+```
+
+---
+
+## Task 3: `useAccountType` hook
+
+**Files:**
+- Create: `frontend/src/hooks/useAccountType.js`
+- Test: `frontend/src/hooks/useAccountType.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/hooks/useAccountType.test.jsx
+import { renderHook } from "@testing-library/react";
+import { useAccountType } from "./useAccountType";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+import { useAuth } from "../context/AuthContext";
+
+test("returns parent/organizer booleans", () => {
+  useAuth.mockReturnValue({ accountType: "organizer", loading: false });
+  const { result } = renderHook(() => useAccountType());
+  expect(result.current).toEqual({
+    accountType: "organizer",
+    isParent: false,
+    isOrganizer: true,
+    loading: false,
+  });
+});
+
+test("returns null+false+false while loading", () => {
+  useAuth.mockReturnValue({ accountType: null, loading: true });
+  const { result } = renderHook(() => useAccountType());
+  expect(result.current.isParent).toBe(false);
+  expect(result.current.isOrganizer).toBe(false);
+  expect(result.current.loading).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- useAccountType`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the hook**
+
+```js
+// frontend/src/hooks/useAccountType.js
+import { useAuth } from "../context/AuthContext";
+
+/**
+ * Thin accessor over AuthContext.accountType. Prefer this over reading
+ * profile.account_type directly so we have one seam to swap if the
+ * source of truth ever moves (e.g., into a JWT claim).
+ */
+export function useAccountType() {
+  const { accountType, loading } = useAuth();
+  return {
+    accountType,
+    isParent: accountType === "parent",
+    isOrganizer: accountType === "organizer",
+    loading,
+  };
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- useAccountType`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/hooks/useAccountType.js frontend/src/hooks/useAccountType.test.jsx
+git commit -m "feat: add useAccountType hook"
+```
+
+---
+
+## Task 4: `<RequireRole>` route guard
+
+**Files:**
+- Create: `frontend/src/components/auth/RequireRole.jsx`
+- Test: `frontend/src/components/auth/RequireRole.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/components/auth/RequireRole.test.jsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import RequireRole from "./RequireRole";
+import { vi } from "vitest";
+
+vi.mock("../../hooks/useAccountType", () => ({ useAccountType: vi.fn() }));
+import { useAccountType } from "../../hooks/useAccountType";
+
+function renderAt(initial, role) {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <Routes>
+        <Route path="/browse" element={<RequireRole role={role}><div>browse-content</div></RequireRole>} />
+        <Route path="/host/dashboard" element={<div>dashboard-content</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test("renders children when role matches", () => {
+  useAccountType.mockReturnValue({ accountType: "parent", isParent: true, isOrganizer: false, loading: false });
+  renderAt("/browse", "parent");
+  expect(screen.getByText("browse-content")).toBeInTheDocument();
+});
+
+test("redirects organizers away from parent routes", () => {
+  useAccountType.mockReturnValue({ accountType: "organizer", isParent: false, isOrganizer: true, loading: false });
+  renderAt("/browse", "parent");
+  expect(screen.getByText("dashboard-content")).toBeInTheDocument();
+});
+
+test("shows loading state while accountType is resolving", () => {
+  useAccountType.mockReturnValue({ accountType: null, isParent: false, isOrganizer: false, loading: true });
+  renderAt("/browse", "parent");
+  expect(screen.queryByText("browse-content")).not.toBeInTheDocument();
+  expect(screen.queryByText("dashboard-content")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- RequireRole`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the guard**
+
+```jsx
+// frontend/src/components/auth/RequireRole.jsx
+import { Navigate } from "react-router-dom";
+import { useAccountType } from "../../hooks/useAccountType";
+
+const HOME_FOR = {
+  parent: "/browse",
+  organizer: "/host/dashboard",
+};
+
+/**
+ * Blocks a route so only the given role can see it. If a user with the
+ * wrong role hits this route, they are bounced to their own home. If
+ * accountType is still loading we render nothing (the global splash
+ * from RequireAuth already covers that case).
+ */
+export default function RequireRole({ role, children }) {
+  const { accountType, loading } = useAccountType();
+  if (loading) return null;
+  if (accountType !== role) {
+    return <Navigate to={HOME_FOR[accountType] || "/"} replace />;
+  }
+  return children;
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- RequireRole`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/auth/RequireRole.jsx frontend/src/components/auth/RequireRole.test.jsx
+git commit -m "feat: add RequireRole route guard"
+```
+
+---
+
+## Task 5: ParentLayout wrapper
+
+**Files:**
+- Create: `frontend/src/layouts/ParentLayout.jsx`
+- Test: `frontend/src/layouts/ParentLayout.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/layouts/ParentLayout.test.jsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ParentLayout from "./ParentLayout";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ signOut: vi.fn(), accountType: "parent" }),
+}));
+
+test("shows PARENT mode label and sage accent", () => {
+  render(
+    <MemoryRouter>
+      <ParentLayout><div>child</div></ParentLayout>
+    </MemoryRouter>
+  );
+  expect(screen.getByText("PARENT")).toBeInTheDocument();
+  expect(screen.getByText("child")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- ParentLayout`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the layout**
+
+```jsx
+// frontend/src/layouts/ParentLayout.jsx
+import TabBar from "../components/layout/TabBar";
+
+/**
+ * Parent-mode wrapper. Adds the small uppercase "PARENT" label at the
+ * top of the page and reserves space for the bottom TabBar. We rely on
+ * TabBar to pick the correct tabs via accountType.
+ *
+ * Accent color (sage #5C6B52) is already the global default in
+ * Kiddaboo, so there's nothing to override here. The Organizer layout
+ * does the overriding.
+ */
+export default function ParentLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-cream flex flex-col" data-mode="parent">
+      <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
+        <div className="px-5 pt-3">
+          <span className="text-[10px] font-bold tracking-[1.5px] text-sage-dark uppercase">
+            Parent
+          </span>
+        </div>
+        <div className="flex-1">{children}</div>
+        <TabBar />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- ParentLayout`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/layouts/ParentLayout.jsx frontend/src/layouts/ParentLayout.test.jsx
+git commit -m "feat: add ParentLayout wrapper"
+```
+
+---
+
+## Task 6: OrganizerLayout wrapper
+
+**Files:**
+- Create: `frontend/src/layouts/OrganizerLayout.jsx`
+- Test: `frontend/src/layouts/OrganizerLayout.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/layouts/OrganizerLayout.test.jsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import OrganizerLayout from "./OrganizerLayout";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ signOut: vi.fn(), accountType: "organizer" }),
+}));
+
+test("shows ORGANIZER mode label with terracotta tint", () => {
+  render(
+    <MemoryRouter>
+      <OrganizerLayout><div>child</div></OrganizerLayout>
+    </MemoryRouter>
+  );
+  const label = screen.getByText("ORGANIZER");
+  expect(label).toBeInTheDocument();
+  expect(label.className).toMatch(/terracotta/);
+  expect(screen.getByText("child")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- OrganizerLayout`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the layout**
+
+```jsx
+// frontend/src/layouts/OrganizerLayout.jsx
+import TabBar from "../components/layout/TabBar";
+
+/**
+ * Organizer-mode wrapper. Terracotta accent, "ORGANIZER" label, and
+ * warmer background so the mode feels visually different from Parent.
+ * We scope the accent with data-mode="organizer" so individual pages
+ * can opt into mode-aware styling via CSS attribute selectors if they
+ * want (e.g., buttons that read from [data-mode=organizer] .btn).
+ */
+export default function OrganizerLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-[#F9F4ED] flex flex-col" data-mode="organizer">
+      <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
+        <div className="px-5 pt-3">
+          <span className="text-[10px] font-bold tracking-[1.5px] text-terracotta uppercase">
+            Organizer
+          </span>
+        </div>
+        <div className="flex-1">{children}</div>
+        <TabBar />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- OrganizerLayout`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/layouts/OrganizerLayout.jsx frontend/src/layouts/OrganizerLayout.test.jsx
+git commit -m "feat: add OrganizerLayout wrapper"
+```
+
+---
+
+## Task 7: TabBar switches from `isHost` to `accountType`
+
+**Files:**
+- Modify: `frontend/src/components/layout/TabBar.jsx`
+- Test: `frontend/src/components/layout/TabBar.test.jsx` (new)
+
+The existing TabBar at `TabBar.jsx:190` reads `const { signOut, isHost } = useAuth();` and picks `isHost ? HOST_TABS : PARENT_TABS`. Switch to `accountType === 'organizer'` so the decision aligns with the new source of truth. Copy change: "Dashboard" (HOST_TABS) → "My Group" per the approved mode-home mockup; "My Group" is also the tab label shown in the design spec D4 bullet. Other tab labels unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/components/layout/TabBar.test.jsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TabBar from "./TabBar";
+import { vi } from "vitest";
+
+vi.mock("../../context/AuthContext");
+import { useAuth } from "../../context/AuthContext";
+
+const setAuth = (accountType) =>
+  useAuth.mockReturnValue({ signOut: vi.fn(), isHost: accountType === "organizer", accountType });
+
+test("parent sees Browse / My Groups / Messages / Profile", () => {
+  setAuth("parent");
+  render(<MemoryRouter><TabBar /></MemoryRouter>);
+  expect(screen.getByLabelText("Browse")).toBeInTheDocument();
+  expect(screen.getByLabelText("My Groups")).toBeInTheDocument();
+  expect(screen.queryByLabelText("My Group")).not.toBeInTheDocument();
+});
+
+test("organizer sees My Group / Members / Messages / Profile", () => {
+  setAuth("organizer");
+  render(<MemoryRouter><TabBar /></MemoryRouter>);
+  expect(screen.getByLabelText("My Group")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Browse")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- TabBar`
+Expected: FAIL (no "My Group" tab, organizer tabs still say "Dashboard").
+
+- [ ] **Step 3: Update TabBar**
+
+Edit `frontend/src/components/layout/TabBar.jsx`:
+
+Replace the `HOST_TABS` array (lines 175–185) with:
+
+```js
+const ORGANIZER_TABS = [
+  {
+    path: "/host/dashboard",
+    matchPaths: ["/host/dashboard", "/my-groups"],
+    label: "My Group",
+    icon: DashboardIcon,
+  },
+  { path: "/host/insights", label: "Members", icon: InsightsIcon },
+  { path: "/messages", label: "Messages", icon: MessagesIcon },
+  { path: "/my-profile", label: "Profile", icon: ProfileIcon },
+];
+```
+
+Replace line 190–191:
+
+```js
+  const { signOut, accountType } = useAuth();
+  const TABS = accountType === "organizer" ? ORGANIZER_TABS : PARENT_TABS;
+```
+
+Rename every remaining `HOST_TABS` reference in the file to `ORGANIZER_TABS` (there should be none after the above edit — grep to confirm).
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- TabBar`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/layout/TabBar.jsx frontend/src/components/layout/TabBar.test.jsx
+git commit -m "feat: TabBar reads accountType; organizer tabs renamed to My Group/Members"
+```
+
+---
+
+## Task 8: ChooseRole signup landing
+
+**Files:**
+- Create: `frontend/src/pages/onboarding/ChooseRole.jsx`
+- Test: `frontend/src/pages/onboarding/ChooseRole.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/pages/onboarding/ChooseRole.test.jsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import ChooseRole from "./ChooseRole";
+import { vi } from "vitest";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => ({
+  ...(await vi.importActual("react-router-dom")),
+  useNavigate: () => navigate,
+}));
+
+test("clicking Parent card routes to /verify?role=parent", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /I'm a Parent/i }));
+  expect(navigate).toHaveBeenCalledWith("/verify?role=parent");
+});
+
+test("clicking Organizer card routes to /verify?role=organizer", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /I'm an Organizer/i }));
+  expect(navigate).toHaveBeenCalledWith("/verify?role=organizer");
+});
+
+test("renders footer note about adding the other role later", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  expect(screen.getByText(/add the other role later/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- ChooseRole`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the picker**
+
+```jsx
+// frontend/src/pages/onboarding/ChooseRole.jsx
+import { useNavigate } from "react-router-dom";
+
+/**
+ * First screen a new user sees. Picks their account_type before any
+ * signup happens. Per design D2, the choice is side-by-side with
+ * role-noun framing. The role is passed to /verify via query param;
+ * that page persists it after auth succeeds and before the profile
+ * row is created.
+ */
+export default function ChooseRole() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center px-6 py-10">
+      <h1
+        className="text-3xl font-bold tracking-tight mb-2"
+        style={{ fontFamily: "'ChunkFive', serif", color: "#5C6B52" }}
+      >
+        Kiddaboo
+      </h1>
+      <p className="text-taupe text-center mb-10">Which best describes you?</p>
+
+      <div className="w-full max-w-md flex flex-col gap-4">
+        <button
+          onClick={() => navigate("/verify?role=parent")}
+          className="bg-white border-2 border-sage rounded-2xl p-6 text-left cursor-pointer hover:bg-sage-light/30 transition-colors"
+        >
+          <div className="text-xs text-sage-dark uppercase tracking-widest font-bold mb-2">Parent</div>
+          <div className="text-lg font-bold text-charcoal mb-1">I'm a Parent</div>
+          <div className="text-sm text-taupe">Looking for a playgroup for my child</div>
+        </button>
+
+        <button
+          onClick={() => navigate("/verify?role=organizer")}
+          className="bg-white border-2 border-terracotta rounded-2xl p-6 text-left cursor-pointer hover:bg-terracotta-light/30 transition-colors"
+        >
+          <div className="text-xs text-terracotta uppercase tracking-widest font-bold mb-2">Organizer</div>
+          <div className="text-lg font-bold text-charcoal mb-1">I'm an Organizer</div>
+          <div className="text-sm text-taupe">Starting or running a playgroup</div>
+        </button>
+      </div>
+
+      <p className="text-xs text-taupe/60 mt-6">You can add the other role later.</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- ChooseRole`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/onboarding/ChooseRole.jsx frontend/src/pages/onboarding/ChooseRole.test.jsx
+git commit -m "feat: add ChooseRole signup landing with Parent/Organizer cards"
+```
+
+---
+
+## Task 9: Persist role from query param after signup
+
+**Files:**
+- Modify: `frontend/src/pages/PhoneVerification.jsx` (or wherever `/verify` currently lives — confirm with `grep -rn "path=\"/verify\"" frontend/src`)
+- Modify: `frontend/src/pages/CreateProfile.jsx` — write `account_type` when the profile row is created
+
+The role chosen on `ChooseRole` arrives at `/verify` as `?role=parent|organizer`. Read it there, stash in `sessionStorage` under `kiddaboo.pendingAccountType`, then write it into the `profiles` row at the point `CreateProfile` inserts/updates.
+
+- [ ] **Step 1: Read the query param and stash it**
+
+In `PhoneVerification.jsx` (or the component mounted at `/verify`), add at the top of the component:
+
+```jsx
+import { useSearchParams } from "react-router-dom";
+// ...existing imports
+
+export default function PhoneVerification() {
+  const [searchParams] = useSearchParams();
+  // Stash role once on mount so it survives the OAuth / magic-link
+  // round-trip and is available to CreateProfile afterwards.
+  useEffect(() => {
+    const role = searchParams.get("role");
+    if (role === "parent" || role === "organizer") {
+      sessionStorage.setItem("kiddaboo.pendingAccountType", role);
+    }
+  }, [searchParams]);
+  // ...rest unchanged
+}
+```
+
+- [ ] **Step 2: Write the role into the profiles row**
+
+In `CreateProfile.jsx`, locate the `.from("profiles").upsert({...})` (or `.update(...)`) call where the profile is persisted. Add `account_type`:
+
+```jsx
+const pendingAccountType = sessionStorage.getItem("kiddaboo.pendingAccountType");
+// Fail closed: if no role was chosen (shouldn't happen after ChooseRole
+// is the entry point), send the user back to pick one.
+if (!pendingAccountType) {
+  navigate("/choose-role");
+  return;
+}
+
+const { error } = await supabase
+  .from("profiles")
+  .upsert({
+    id: user.id,
+    first_name,
+    last_name,
+    // ...existing fields
+    account_type: pendingAccountType,
+  });
+
+if (!error) {
+  sessionStorage.removeItem("kiddaboo.pendingAccountType");
+  // ...existing navigate
+}
+```
+
+- [ ] **Step 3: Manually verify**
+
+Run dev server (`npm run dev`), visit `/choose-role`, click Organizer, complete signup. Check `select account_type from profiles where id = '<new user id>';` returns `organizer`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/PhoneVerification.jsx frontend/src/pages/CreateProfile.jsx
+git commit -m "feat: persist chosen role from ChooseRole into profiles.account_type"
+```
+
+---
+
+## Task 10: Wire layouts + role guards into App.jsx
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+
+Replace each `<AppLayout>` wrapper with the role-specific layout guarded by `<RequireRole>`, and add the `/choose-role` route. The existing `AppLayout` stays for now as a thin shared wrapper; the role-specific ones are new.
+
+- [ ] **Step 1: Add the new imports at the top of App.jsx**
+
+```jsx
+import ParentLayout from "./layouts/ParentLayout";
+import OrganizerLayout from "./layouts/OrganizerLayout";
+import RequireRole from "./components/auth/RequireRole";
+import ChooseRole from "./pages/onboarding/ChooseRole";
+```
+
+- [ ] **Step 2: Add the `/choose-role` public route**
+
+Above the existing `/` route (line 46):
+
+```jsx
+<Route path="/choose-role" element={<ChooseRole />} />
+```
+
+- [ ] **Step 3: Replace Parent-mode routes**
+
+Lines 77–80 change from:
+```jsx
+<Route path="/browse" element={<RequireAuth><AppLayout><Browse /></AppLayout></RequireAuth>} />
+<Route path="/my-groups" element={<RequireAuth><AppLayout><MyGroups /></AppLayout></RequireAuth>} />
+```
+to:
+```jsx
+<Route path="/browse" element={<RequireAuth><RequireRole role="parent"><ParentLayout><Browse /></ParentLayout></RequireRole></RequireAuth>} />
+<Route path="/my-groups" element={<RequireAuth><RequireRole role="parent"><ParentLayout><MyGroups /></ParentLayout></RequireRole></RequireAuth>} />
+```
+
+- [ ] **Step 4: Replace Organizer-mode routes**
+
+Lines 81–82 change from:
+```jsx
+<Route path="/host/dashboard" element={<RequireAuth><AppLayout><HostDashboard /></AppLayout></RequireAuth>} />
+<Route path="/host/insights" element={<RequireAuth><AppLayout><HostInsights /></AppLayout></RequireAuth>} />
+```
+to:
+```jsx
+<Route path="/host/dashboard" element={<RequireAuth><RequireRole role="organizer"><OrganizerLayout><HostDashboard /></OrganizerLayout></RequireRole></RequireAuth>} />
+<Route path="/host/insights" element={<RequireAuth><RequireRole role="organizer"><OrganizerLayout><HostInsights /></OrganizerLayout></RequireRole></RequireAuth>} />
+```
+
+- [ ] **Step 5: Leave shared routes alone**
+
+`/messages` and `/my-profile` stay wrapped in `<AppLayout>` — these are layout-neutral. No `<RequireRole>` on them.
+
+- [ ] **Step 6: Update Welcome.jsx redirect logic**
+
+In `frontend/src/pages/Welcome.jsx` lines 11–21, replace the `isHost` redirect with `accountType`:
+
+```jsx
+const { user, profile, loading } = useAuth();
+
+useEffect(() => {
+  if (!loading && user) {
+    if (!profile?.first_name) {
+      navigate("/profile");
+    } else if (profile.account_type === "organizer") {
+      navigate("/host/dashboard");
+    } else {
+      navigate("/browse");
+    }
+  }
+}, [user, profile, loading, navigate]);
+```
+
+- [ ] **Step 7: Point the "Get Started" button at /choose-role**
+
+Line 82 of `Welcome.jsx`:
+
+```jsx
+<Button fullWidth onClick={() => navigate("/choose-role")}>
+  Get Started
+</Button>
+```
+
+Delete the existing "Host a Playgroup" secondary button (line 85–87) — that path now goes through `ChooseRole` → Organizer card.
+
+- [ ] **Step 8: Smoke test**
+
+Run `npm run dev`, log in as an existing `'organizer'`, visit `/browse` — should redirect to `/host/dashboard`. Log out, sign up via `/choose-role` → Parent → verify `/host/dashboard` redirects back to `/browse`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/App.jsx frontend/src/pages/Welcome.jsx
+git commit -m "feat: wire ParentLayout/OrganizerLayout + RequireRole guards; add /choose-role route"
+```
+
+---
+
+## Task 11: Rename user-facing "Host" → "Organizer"
+
+This is a grep-and-replace task across 10 specific strings in 9 files. DB identifiers and route paths stay unchanged.
+
+**Files to modify:**
+- `frontend/src/pages/Welcome.jsx:86` (already handled in Task 10 step 7 — skip)
+- `frontend/src/pages/Browse.jsx:482`
+- `frontend/src/pages/MyGroups.jsx:260`
+- `frontend/src/pages/MyProfile.jsx:93`
+- `frontend/src/pages/host/HostDashboard.jsx:398, 519 (comment), 559`
+- `frontend/src/pages/host/HostInsights.jsx:241`
+- `frontend/src/pages/host/HostPremium.jsx:58, 75, 130, 168, 180`
+- `frontend/src/pages/admin/SubscriptionsTab.jsx:54, 154`
+- `frontend/src/test/regression.test.jsx:187`
+
+- [ ] **Step 1: Apply the renames**
+
+Perform these exact replacements:
+
+| File | Old string | New string |
+|---|---|---|
+| `Browse.jsx` | `Host a Playgroup` | `Organize a Playgroup` |
+| `MyGroups.jsx` | `Host a Playgroup` | `Organize a Playgroup` |
+| `MyProfile.jsx` | `"Host Premium Member" : "Upgrade to Host Premium"` | `"Organizer Premium Member" : "Upgrade to Organizer Premium"` |
+| `HostDashboard.jsx` | `Host a Playgroup` | `Organize a Playgroup` |
+| `HostDashboard.jsx` | `Go Host Premium` | `Go Organizer Premium` |
+| `HostInsights.jsx` | `Host a Playgroup` | `Organize a Playgroup` |
+| `HostPremium.jsx` | `useDocumentTitle("Host Premium")` | `useDocumentTitle("Organizer Premium")` |
+| `HostPremium.jsx` | `"You're now a Host Premium member!"` | `"You're now an Organizer Premium member!"` |
+| `HostPremium.jsx` | `>Host Premium<` | `>Organizer Premium<` |
+| `HostPremium.jsx` | `You're Host Premium!` | `You're Organizer Premium!` |
+| `HostPremium.jsx` | `Your Host Premium benefits` | `Your Organizer Premium benefits` |
+| `SubscriptionsTab.jsx:54` | `return isHostSub(sub) ? "Host Premium" : "Joiner";` | `return isHostSub(sub) ? "Organizer Premium" : "Parent";` |
+| `SubscriptionsTab.jsx:154` | `{f === "host" ? "Host Premium" : f === "joiner" ? "Joiner" : "All"}` | `{f === "host" ? "Organizer Premium" : f === "joiner" ? "Parent" : "All"}` |
+| `regression.test.jsx:187` | `expect(screen.getByText("Host a Playgroup")).toBeInTheDocument();` | `expect(screen.getByText("Organize a Playgroup")).toBeInTheDocument();` |
+
+Comment block `{/* Host Premium analytics / upsell */}` in HostDashboard.jsx is a code comment, not user-facing. **Leave it alone** — keeping it aligned with DB `host_premium` type.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd frontend && npm test`
+Expected: All tests pass, including the updated regression test.
+
+- [ ] **Step 3: Grep to confirm no stray user-facing "Host" text**
+
+Run:
+```bash
+cd /Users/sureshkumar/Kiddaboo && \
+  grep -rn "Host " frontend/src/pages frontend/src/components | \
+  grep -v "HostCard\|HostContext\|HostDashboard\|HostInsights\|HostPremium\|HostPhotos\|HostSuccess\|host_\|/host/\|isHost"
+```
+Expected: no lines output. Any hits are remaining user-facing strings that need renaming.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u frontend/src
+git commit -m "feat: rename user-facing 'Host' → 'Organizer' across 9 files"
+```
+
+---
+
+## Task 12: M1 acceptance — manual QA and deploy
+
+- [ ] **Step 1: Run the full test suite one more time**
+
+Run: `cd frontend && npm test`
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke test checklist**
+
+1. New user visits `/` → Get Started → `/choose-role` shows both cards
+2. Pick Parent → complete signup → land on `/browse` with sage "PARENT" label at top, Parent bottom nav
+3. In another browser, pick Organizer → complete signup → land on `/host/dashboard` with terracotta "ORGANIZER" label, `My Group / Members / Messages / Profile` nav
+4. Parent manually navigates to `/host/dashboard` → silently redirected to `/browse`
+5. Organizer manually navigates to `/browse` → silently redirected to `/host/dashboard`
+6. `/my-profile` renders for both roles; Parent sees "Upgrade to Premium", Organizer sees "Upgrade to Organizer Premium"
+7. Admin `/admin` subscriptions tab shows the filter label as "Organizer Premium"
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+M1 is now live. Do NOT start M2 until M1 has been on production for at least one day with no regressions reported.
+
+---
+
+# M2 — Phone OTP Verification
+
+## Task 13: phone_otp_challenges table + profiles columns
+
+**Files:**
+- Create: `supabase/migrations/20260416000002_add_phone_verification.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 20260416000002_add_phone_verification.sql
+
+-- Phone number on profiles. We store the E.164 value in `phone_number`
+-- and set `phone_verified_at` on successful OTP verification. The
+-- value is stored in plaintext because we need it for re-verification
+-- and SMS resends; RLS and column-level grants protect it.
+
+ALTER TABLE profiles ADD COLUMN phone_number TEXT;
+ALTER TABLE profiles ADD COLUMN phone_verified_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_phone_number_unique
+  ON profiles (phone_number)
+  WHERE phone_number IS NOT NULL;
+
+-- Challenges table. Rows are created when send-otp runs and consumed
+-- when verify-otp runs. We store a bcrypt-ish hash of the code rather
+-- than the plaintext, so an attacker with DB read can't immediately
+-- complete a challenge.
+
+CREATE TABLE phone_otp_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  phone_number TEXT NOT NULL,
+  code_hash TEXT NOT NULL,
+  attempts INT NOT NULL DEFAULT 0,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX phone_otp_challenges_user_id_idx ON phone_otp_challenges (user_id);
+CREATE INDEX phone_otp_challenges_expires_at_idx ON phone_otp_challenges (expires_at);
+
+ALTER TABLE phone_otp_challenges ENABLE ROW LEVEL SECURITY;
+
+-- Users can see only their own challenges (for UI "code sent" state).
+CREATE POLICY phone_otp_self_read ON phone_otp_challenges
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- No INSERT/UPDATE/DELETE policies for clients; only the edge
+-- functions (service role) write to this table.
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `supabase db push`
+Expected: migration applied.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260416000002_add_phone_verification.sql
+git commit -m "feat: add phone_otp_challenges table + profiles.phone columns"
+```
+
+---
+
+## Task 14: send-otp edge function
+
+**Files:**
+- Create: `supabase/functions/send-otp/index.ts`
+- Modify: `supabase/config.toml` — register function with `verify_jwt = true`
+
+- [ ] **Step 1: Write the function**
+
+```ts
+// supabase/functions/send-otp/index.ts
+//
+// Sends a 6-digit OTP to the user's phone via Twilio. Requires a
+// Supabase user JWT (verify_jwt = true in config). Rate limited to
+// 3 sends per phone per hour; challenge expires in 10 minutes.
+
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const TWILIO_SID = Deno.env.get("TWILIO_ACCOUNT_SID")!;
+const TWILIO_TOKEN = Deno.env.get("TWILIO_AUTH_TOKEN")!;
+const TWILIO_FROM = Deno.env.get("TWILIO_FROM_NUMBER")!;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function hashCode(code: string): Promise<string> {
+  const buf = new TextEncoder().encode(code + "|kiddaboo-otp-v1");
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomCode() {
+  const n = crypto.getRandomValues(new Uint32Array(1))[0] % 1_000_000;
+  return n.toString().padStart(6, "0");
+}
+
+async function sendSms(to: string, body: string) {
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_SID}/Messages.json`;
+  const params = new URLSearchParams({ To: to, From: TWILIO_FROM, Body: body });
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: "Basic " + btoa(`${TWILIO_SID}:${TWILIO_TOKEN}`),
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: params,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`twilio ${res.status}: ${text}`);
+  }
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+
+  const authHeader = req.headers.get("authorization") || "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token) return json({ error: "unauthorized" }, 401);
+
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE);
+  const { data: userData, error: userErr } = await admin.auth.getUser(token);
+  if (userErr || !userData?.user) return json({ error: "unauthorized" }, 401);
+  const userId = userData.user.id;
+
+  let phone: string;
+  try {
+    ({ phone } = await req.json());
+  } catch {
+    return json({ error: "bad_json" }, 400);
+  }
+  if (!/^\+[1-9]\d{6,14}$/.test(phone || "")) {
+    return json({ error: "invalid_phone" }, 400);
+  }
+
+  // Rate limit: max 3 sends per phone per hour.
+  const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const { count } = await admin
+    .from("phone_otp_challenges")
+    .select("id", { count: "exact", head: true })
+    .eq("phone_number", phone)
+    .gte("created_at", since);
+  if ((count ?? 0) >= 3) {
+    return json({ error: "rate_limited" }, 429);
+  }
+
+  const code = randomCode();
+  const codeHash = await hashCode(code);
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+  const { error: insErr } = await admin.from("phone_otp_challenges").insert({
+    user_id: userId,
+    phone_number: phone,
+    code_hash: codeHash,
+    expires_at: expiresAt,
+  });
+  if (insErr) return json({ error: "db_error", detail: insErr.message }, 500);
+
+  try {
+    await sendSms(phone, `Kiddaboo verification code: ${code}. Expires in 10 minutes.`);
+  } catch (err) {
+    return json({ error: "sms_failed", detail: String(err) }, 502);
+  }
+
+  return json({ ok: true, expires_at: expiresAt });
+});
+```
+
+- [ ] **Step 2: Register in config.toml**
+
+Append to `supabase/config.toml`:
+
+```toml
+[functions.send-otp]
+verify_jwt = true
+
+[functions.verify-otp]
+verify_jwt = true
+```
+
+- [ ] **Step 3: Set the Twilio secrets**
+
+Run:
+```bash
+supabase secrets set TWILIO_ACCOUNT_SID=<sid> TWILIO_AUTH_TOKEN=<token> TWILIO_FROM_NUMBER=+1xxxxxxxxxx
+```
+
+Suresh owns procuring the Twilio trial credentials; this step is blocked until he provides them. The rest of M2 can be coded against a stubbed SMS send (skip the `sendSms(...)` call behind an `if (Deno.env.get("OTP_STUB") === "1")` guard if testing without Twilio).
+
+- [ ] **Step 4: Deploy**
+
+Run: `supabase functions deploy send-otp`
+Expected: deploy succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/send-otp/index.ts supabase/config.toml
+git commit -m "feat: add send-otp edge function with Twilio + rate limit"
+```
+
+---
+
+## Task 15: verify-otp edge function
+
+**Files:**
+- Create: `supabase/functions/verify-otp/index.ts`
+
+- [ ] **Step 1: Write the function**
+
+```ts
+// supabase/functions/verify-otp/index.ts
+//
+// Consumes a phone_otp_challenges row: checks code hash, attempts,
+// expiry. On success, sets profiles.phone_verified_at + phone_number.
+
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const MAX_ATTEMPTS = 3;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function hashCode(code: string): Promise<string> {
+  const buf = new TextEncoder().encode(code + "|kiddaboo-otp-v1");
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+
+  const authHeader = req.headers.get("authorization") || "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token) return json({ error: "unauthorized" }, 401);
+
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE);
+  const { data: userData, error: userErr } = await admin.auth.getUser(token);
+  if (userErr || !userData?.user) return json({ error: "unauthorized" }, 401);
+  const userId = userData.user.id;
+
+  let phone: string, code: string;
+  try {
+    ({ phone, code } = await req.json());
+  } catch {
+    return json({ error: "bad_json" }, 400);
+  }
+  if (!phone || !/^\d{6}$/.test(code || "")) {
+    return json({ error: "invalid_input" }, 400);
+  }
+
+  // Grab the latest unexpired, unconsumed challenge for this user+phone.
+  const { data: challenges, error: selErr } = await admin
+    .from("phone_otp_challenges")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("phone_number", phone)
+    .is("consumed_at", null)
+    .gte("expires_at", new Date().toISOString())
+    .order("created_at", { ascending: false })
+    .limit(1);
+  if (selErr) return json({ error: "db_error", detail: selErr.message }, 500);
+  const challenge = challenges?.[0];
+  if (!challenge) return json({ error: "no_active_challenge" }, 410);
+  if (challenge.attempts >= MAX_ATTEMPTS) {
+    return json({ error: "too_many_attempts" }, 429);
+  }
+
+  const codeHash = await hashCode(code);
+  if (codeHash !== challenge.code_hash) {
+    await admin
+      .from("phone_otp_challenges")
+      .update({ attempts: challenge.attempts + 1 })
+      .eq("id", challenge.id);
+    return json({ error: "code_mismatch", attempts_left: MAX_ATTEMPTS - challenge.attempts - 1 }, 400);
+  }
+
+  const now = new Date().toISOString();
+  const { error: consumeErr } = await admin
+    .from("phone_otp_challenges")
+    .update({ consumed_at: now })
+    .eq("id", challenge.id);
+  if (consumeErr) return json({ error: "db_error", detail: consumeErr.message }, 500);
+
+  const { error: profErr } = await admin
+    .from("profiles")
+    .update({ phone_number: phone, phone_verified_at: now })
+    .eq("id", userId);
+  if (profErr) return json({ error: "db_error", detail: profErr.message }, 500);
+
+  return json({ ok: true, verified_at: now });
+});
+```
+
+- [ ] **Step 2: Deploy**
+
+Run: `supabase functions deploy verify-otp`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/functions/verify-otp/index.ts
+git commit -m "feat: add verify-otp edge function"
+```
+
+---
+
+## Task 16: `usePhoneVerification` hook
+
+**Files:**
+- Create: `frontend/src/hooks/usePhoneVerification.js`
+- Test: `frontend/src/hooks/usePhoneVerification.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/hooks/usePhoneVerification.test.jsx
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePhoneVerification } from "./usePhoneVerification";
+import { supabase } from "../lib/supabase";
+import { vi } from "vitest";
+
+vi.mock("../lib/supabase");
+
+test("sendCode invokes the send-otp function with the phone", async () => {
+  supabase.functions.invoke.mockResolvedValue({ data: { ok: true }, error: null });
+  const { result } = renderHook(() => usePhoneVerification());
+  await act(async () => {
+    await result.current.sendCode("+15551234567");
+  });
+  expect(supabase.functions.invoke).toHaveBeenCalledWith("send-otp", { body: { phone: "+15551234567" } });
+  await waitFor(() => expect(result.current.status).toBe("code_sent"));
+});
+
+test("verifyCode invokes verify-otp and transitions to verified on ok", async () => {
+  supabase.functions.invoke.mockResolvedValue({ data: { ok: true, verified_at: "now" }, error: null });
+  const { result } = renderHook(() => usePhoneVerification());
+  await act(async () => {
+    await result.current.verifyCode("+15551234567", "123456");
+  });
+  expect(supabase.functions.invoke).toHaveBeenCalledWith("verify-otp", { body: { phone: "+15551234567", code: "123456" } });
+  await waitFor(() => expect(result.current.status).toBe("verified"));
+});
+
+test("verifyCode surfaces mismatch error", async () => {
+  supabase.functions.invoke.mockResolvedValue({ data: null, error: { message: "code_mismatch" } });
+  const { result } = renderHook(() => usePhoneVerification());
+  await act(async () => {
+    await result.current.verifyCode("+15551234567", "000000");
+  });
+  expect(result.current.error).toBe("code_mismatch");
+  expect(result.current.status).toBe("error");
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- usePhoneVerification`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the hook**
+
+```js
+// frontend/src/hooks/usePhoneVerification.js
+import { useState } from "react";
+import { supabase } from "../lib/supabase";
+
+/**
+ * Drives the OTP UI. Status machine:
+ *   idle → sending → code_sent → verifying → verified
+ *                                        ↘ error
+ */
+export function usePhoneVerification() {
+  const [status, setStatus] = useState("idle");
+  const [error, setError] = useState(null);
+
+  async function sendCode(phone) {
+    setStatus("sending");
+    setError(null);
+    const { error } = await supabase.functions.invoke("send-otp", { body: { phone } });
+    if (error) {
+      setStatus("error");
+      setError(error.message || "send_failed");
+      return { error };
+    }
+    setStatus("code_sent");
+    return { error: null };
+  }
+
+  async function verifyCode(phone, code) {
+    setStatus("verifying");
+    setError(null);
+    const { data, error } = await supabase.functions.invoke("verify-otp", { body: { phone, code } });
+    if (error || !data?.ok) {
+      setStatus("error");
+      setError(error?.message || "verify_failed");
+      return { error: error ?? new Error("verify_failed") };
+    }
+    setStatus("verified");
+    return { data, error: null };
+  }
+
+  function reset() {
+    setStatus("idle");
+    setError(null);
+  }
+
+  return { status, error, sendCode, verifyCode, reset };
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- usePhoneVerification`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/hooks/usePhoneVerification.js frontend/src/hooks/usePhoneVerification.test.jsx
+git commit -m "feat: add usePhoneVerification hook"
+```
+
+---
+
+## Task 17: PhoneVerify onboarding page
+
+**Files:**
+- Create: `frontend/src/pages/onboarding/PhoneVerify.jsx`
+- Test: `frontend/src/pages/onboarding/PhoneVerify.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/pages/onboarding/PhoneVerify.test.jsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import PhoneVerify from "./PhoneVerify";
+import { vi } from "vitest";
+
+const sendCode = vi.fn().mockResolvedValue({ error: null });
+const verifyCode = vi.fn().mockResolvedValue({ data: { ok: true }, error: null });
+let status = "idle";
+vi.mock("../../hooks/usePhoneVerification", () => ({
+  usePhoneVerification: () => ({ status, error: null, sendCode, verifyCode, reset: vi.fn() }),
+}));
+
+test("full flow: enter phone, send code, enter code, verified", async () => {
+  render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
+  fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: "+15551234567" } });
+  fireEvent.click(screen.getByRole("button", { name: /send code/i }));
+  await waitFor(() => expect(sendCode).toHaveBeenCalledWith("+15551234567"));
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- PhoneVerify`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the page**
+
+```jsx
+// frontend/src/pages/onboarding/PhoneVerify.jsx
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Button from "../../components/ui/Button";
+import { usePhoneVerification } from "../../hooks/usePhoneVerification";
+
+/**
+ * OTP step. Two stages:
+ *   1. Ask for E.164 phone → "Send code"
+ *   2. Show 6-digit input → "Verify"
+ * On verify success, navigate to the next onboarding step (/children
+ * for Parents, /host/create for Organizers). The caller route decides
+ * where `next` points; we read it from history state.
+ */
+export default function PhoneVerify() {
+  const navigate = useNavigate();
+  const { status, error, sendCode, verifyCode } = usePhoneVerification();
+  const [phone, setPhone] = useState("");
+  const [code, setCode] = useState("");
+
+  async function onSend(e) {
+    e.preventDefault();
+    await sendCode(phone);
+  }
+
+  async function onVerify(e) {
+    e.preventDefault();
+    const { error: err } = await verifyCode(phone, code);
+    if (!err) {
+      const role = sessionStorage.getItem("kiddaboo.pendingAccountType");
+      navigate(role === "organizer" ? "/host/create" : "/children");
+    }
+  }
+
+  const showCodeStep = status === "code_sent" || status === "verifying" || status === "error";
+
+  return (
+    <div className="min-h-screen bg-cream px-6 py-10 flex flex-col">
+      <div className="max-w-md mx-auto w-full">
+        <h1 className="text-2xl font-bold text-charcoal mb-2">Verify your phone</h1>
+        <p className="text-sm text-taupe mb-8">
+          We send a 6-digit code to make sure you're a real person. We won't share your number.
+        </p>
+
+        {!showCodeStep && (
+          <form onSubmit={onSend} className="flex flex-col gap-4">
+            <label className="text-sm text-charcoal" htmlFor="phone">Phone number</label>
+            <input
+              id="phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="+1 555 123 4567"
+              className="border border-cream-dark rounded-xl px-4 py-3"
+              required
+            />
+            <Button type="submit" disabled={status === "sending"}>
+              {status === "sending" ? "Sending…" : "Send code"}
+            </Button>
+          </form>
+        )}
+
+        {showCodeStep && (
+          <form onSubmit={onVerify} className="flex flex-col gap-4">
+            <label className="text-sm text-charcoal" htmlFor="code">Enter the 6-digit code</label>
+            <input
+              id="code"
+              inputMode="numeric"
+              pattern="\d{6}"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              className="border border-cream-dark rounded-xl px-4 py-3 text-center text-2xl tracking-widest"
+              required
+            />
+            {error && <p className="text-xs text-terracotta">{error === "code_mismatch" ? "Code doesn't match. Try again." : "Something went wrong. Try again."}</p>}
+            <Button type="submit" disabled={status === "verifying"}>
+              {status === "verifying" ? "Verifying…" : "Verify"}
+            </Button>
+            <button
+              type="button"
+              onClick={() => sendCode(phone)}
+              className="text-xs text-sage underline"
+            >
+              Resend code
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- PhoneVerify`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/onboarding/PhoneVerify.jsx frontend/src/pages/onboarding/PhoneVerify.test.jsx
+git commit -m "feat: add PhoneVerify onboarding page"
+```
+
+---
+
+## Task 18: Insert PhoneVerify into onboarding routes
+
+**Files:**
+- Modify: `frontend/src/App.jsx`
+- Modify: `frontend/src/pages/CreateProfile.jsx` — navigate to `/verify-phone` after profile save
+
+- [ ] **Step 1: Add the route**
+
+In `App.jsx`, under Onboarding section:
+
+```jsx
+<Route path="/verify-phone" element={<RequireAuth><PhoneVerify /></RequireAuth>} />
+```
+
+And import `PhoneVerify` at the top.
+
+- [ ] **Step 2: Redirect from CreateProfile**
+
+In `CreateProfile.jsx`, after the successful `profiles.upsert(...)`, change the navigate target. Parents go `/profile` → `/verify-phone` → `/children` → `/browse`. Organizers go `/profile` → `/verify-phone` → `/host/create` → `/host/dashboard`.
+
+Replace whatever `navigate("/children")` / `navigate("/host/create")` call is currently in `CreateProfile.jsx` with `navigate("/verify-phone")`.
+
+`PhoneVerify` itself (Task 17) already branches to the correct next step based on the stashed role.
+
+- [ ] **Step 3: Block join requests for unverified users**
+
+In `frontend/src/hooks/useSubscription.js`, expand `canSendJoinRequest` (line 98) to require phone verification:
+
+```js
+const canSendJoinRequest = (isPremium || joinRequestsRemaining > 0) && !!profile?.phone_verified_at;
+```
+
+`profile` needs to come from `useAuth()`. Add:
+```js
+import { useAuth } from "../context/AuthContext";
+// ...
+const { user, profile } = useAuth();
+```
+
+- [ ] **Step 4: Manually verify**
+
+Sign up a fresh user: phone step appears after profile, code sends, verify lands on the correct next page. Try to send a join request as an unverified user → button disabled / toast "Verify your phone first."
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.jsx frontend/src/pages/CreateProfile.jsx frontend/src/hooks/useSubscription.js
+git commit -m "feat: gate join requests on phone verification; insert PhoneVerify step"
+```
+
+---
+
+## Task 19: M2 acceptance
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd frontend && npm test`
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke test**
+
+1. New Parent signup → phone step → SMS arrives → verify → children step → browse
+2. Re-enter wrong code 3x → "too_many_attempts" error; request new code succeeds
+3. Request 4 codes in an hour → 4th returns `rate_limited`
+4. Unverified user on `/browse` → "Send join request" button disabled with explanation
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+M2 live.
+
+---
+
+# M3 — Profile Panel Trust Redesign
+
+## Task 20: RoleBadge component
+
+**Files:**
+- Create: `frontend/src/components/profile/RoleBadge.jsx`
+- Test: `frontend/src/components/profile/RoleBadge.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/components/profile/RoleBadge.test.jsx
+import { render, screen } from "@testing-library/react";
+import RoleBadge from "./RoleBadge";
+
+test("renders Organizer pill with terracotta", () => {
+  render(<RoleBadge role="organizer" />);
+  const badge = screen.getByText("Organizer");
+  expect(badge.className).toMatch(/terracotta/);
+});
+
+test("renders Parent small text in sage", () => {
+  render(<RoleBadge role="parent" />);
+  expect(screen.getByText("Parent")).toBeInTheDocument();
+});
+
+test("renders nothing for unknown role", () => {
+  const { container } = render(<RoleBadge role={null} />);
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- RoleBadge`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```jsx
+// frontend/src/components/profile/RoleBadge.jsx
+export default function RoleBadge({ role }) {
+  if (role === "organizer") {
+    return (
+      <span className="bg-terracotta text-white text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide">
+        Organizer
+      </span>
+    );
+  }
+  if (role === "parent") {
+    return <span className="text-sage-dark text-[10px] font-medium">Parent</span>;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- RoleBadge`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/profile/RoleBadge.jsx frontend/src/components/profile/RoleBadge.test.jsx
+git commit -m "feat: add RoleBadge component"
+```
+
+---
+
+## Task 21: VerifiedBadge component
+
+**Files:**
+- Create: `frontend/src/components/profile/VerifiedBadge.jsx`
+- Test: `frontend/src/components/profile/VerifiedBadge.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/components/profile/VerifiedBadge.test.jsx
+import { render, screen } from "@testing-library/react";
+import VerifiedBadge from "./VerifiedBadge";
+
+test("renders check icon when verified", () => {
+  render(<VerifiedBadge verified />);
+  expect(screen.getByLabelText(/verified/i)).toBeInTheDocument();
+});
+
+test("renders nothing when not verified", () => {
+  const { container } = render(<VerifiedBadge verified={false} />);
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- VerifiedBadge`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```jsx
+// frontend/src/components/profile/VerifiedBadge.jsx
+/**
+ * Small green circle with a white check, meant to sit on the bottom-
+ * right of an avatar. Caller absolute-positions it.
+ */
+export default function VerifiedBadge({ verified }) {
+  if (!verified) return null;
+  return (
+    <span
+      role="img"
+      aria-label="Verified"
+      className="bg-sage-dark w-5 h-5 rounded-full border-2 border-white flex items-center justify-center text-white text-[11px]"
+    >
+      ✓
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- VerifiedBadge`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/profile/VerifiedBadge.jsx frontend/src/components/profile/VerifiedBadge.test.jsx
+git commit -m "feat: add VerifiedBadge component"
+```
+
+---
+
+## Task 22: ProfilePanel (trust-signal v1)
+
+**Files:**
+- Create: `frontend/src/components/profile/ProfilePanel.jsx`
+- Test: `frontend/src/components/profile/ProfilePanel.test.jsx`
+
+Per design D8, v1 signals are: avatar+verified, real name, children/senior line, verified label, role+neighborhood+distance, stat strip (kids count, groups joined), children card, about, tags, message button. Explicitly excluded from v1: tenure, review rating, groups in common.
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// frontend/src/components/profile/ProfilePanel.test.jsx
+import { render, screen } from "@testing-library/react";
+import ProfilePanel from "./ProfilePanel";
+
+const sample = {
+  id: "p1",
+  first_name: "Priya",
+  last_name: "Sharma",
+  photo_url: null,
+  phone_verified_at: "2026-03-01T00:00:00Z",
+  account_type: "organizer",
+  zip_code: "11530",
+  bio: "First-time mom.",
+  philosophy_tags: ["Outdoor play"],
+  children: [{ name: "Maya", age: 3 }],
+  groups_joined_count: 2,
+};
+
+test("renders name, verified label, role label", () => {
+  render(<ProfilePanel profile={sample} />);
+  expect(screen.getByText("Priya Sharma")).toBeInTheDocument();
+  expect(screen.getByText(/verified parent|verified family/i)).toBeInTheDocument();
+  expect(screen.getByText("Organizer")).toBeInTheDocument();
+});
+
+test("does not render tenure, rating, or groups-in-common (v1 deferred)", () => {
+  render(<ProfilePanel profile={sample} />);
+  expect(screen.queryByText(/on kiddaboo/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/⭐/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/in common/i)).not.toBeInTheDocument();
+});
+
+test("renders children card", () => {
+  render(<ProfilePanel profile={sample} />);
+  expect(screen.getByText(/Maya/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- ProfilePanel`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```jsx
+// frontend/src/components/profile/ProfilePanel.jsx
+import RoleBadge from "./RoleBadge";
+import VerifiedBadge from "./VerifiedBadge";
+
+function VerifiedLabel({ accountType }) {
+  return (
+    <div className="text-xs text-sage-dark font-bold mt-1">
+      ✓ {accountType === "organizer" ? "Verified organizer" : "Verified parent"}
+    </div>
+  );
+}
+
+function ChildrenCard({ children }) {
+  if (!children || children.length === 0) return null;
+  return (
+    <div className="mb-4">
+      <div className="text-[10px] uppercase tracking-widest text-taupe font-bold mb-1.5">Children</div>
+      <div className="flex gap-2 flex-wrap">
+        {children.map((c) => (
+          <span
+            key={c.name}
+            className="bg-white border border-cream-dark rounded-xl px-3 py-2 text-xs text-charcoal"
+          >
+            {c.name}, {c.age}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The sheet that slides up when you tap a member inside a playgroup.
+ * v1 intentionally omits tenure, review rating, and groups-in-common —
+ * those signals are either unreliable on a brand-new network or
+ * require more data than we have. Add them back via a prop when v2
+ * lands.
+ */
+export default function ProfilePanel({ profile, onMessage }) {
+  if (!profile) return null;
+  const verified = !!profile.phone_verified_at;
+  const fullName = `${profile.first_name ?? ""} ${profile.last_name ?? ""}`.trim();
+
+  return (
+    <div className="bg-cream rounded-t-2xl p-5 max-w-md mx-auto">
+      {/* Avatar + verified */}
+      <div className="flex flex-col items-center text-center mb-3">
+        <div className="relative inline-block">
+          <div className="w-20 h-20 rounded-full bg-sage-light border-[3px] border-white shadow" />
+          <div className="absolute bottom-0 right-0">
+            <VerifiedBadge verified={verified} />
+          </div>
+        </div>
+        <div className="font-bold text-charcoal mt-2">{fullName || "Kiddaboo user"}</div>
+        {verified && <VerifiedLabel accountType={profile.account_type} />}
+      </div>
+
+      {/* Role + neighborhood */}
+      <div className="text-center py-3 border-t border-b border-cream-dark mb-4">
+        <div className="flex justify-center mb-1"><RoleBadge role={profile.account_type} /></div>
+        {profile.zip_code && (
+          <div className="text-xs text-taupe">Zip {profile.zip_code}</div>
+        )}
+      </div>
+
+      {/* Stat strip — kids + groups joined. No tenure, no rating. */}
+      <div className="grid grid-cols-2 gap-2 text-center bg-white rounded-xl border border-cream-dark py-3 mb-4">
+        <div>
+          <div className="text-base font-bold text-charcoal">{profile.children?.length ?? 0}</div>
+          <div className="text-[9px] uppercase text-taupe">Kids</div>
+        </div>
+        <div className="border-l border-cream-dark">
+          <div className="text-base font-bold text-charcoal">{profile.groups_joined_count ?? 0}</div>
+          <div className="text-[9px] uppercase text-taupe">Groups</div>
+        </div>
+      </div>
+
+      <ChildrenCard children={profile.children} />
+
+      {profile.bio && (
+        <div className="mb-4">
+          <div className="text-[10px] uppercase tracking-widest text-taupe font-bold mb-1.5">About</div>
+          <div className="text-sm text-charcoal leading-relaxed">{profile.bio}</div>
+        </div>
+      )}
+
+      {profile.philosophy_tags?.length > 0 && (
+        <div className="mb-4">
+          <div className="text-[10px] uppercase tracking-widest text-taupe font-bold mb-1.5">Parenting style</div>
+          <div className="flex flex-wrap gap-1.5">
+            {profile.philosophy_tags.map((t) => (
+              <span key={t} className="bg-sage-light text-sage-dark rounded-full text-[11px] px-2 py-0.5">
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={onMessage}
+        className="w-full bg-sage-dark text-white rounded-xl py-3 font-bold text-sm cursor-pointer border-none"
+      >
+        Message
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `npm test -- ProfilePanel`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/profile/ProfilePanel.jsx frontend/src/components/profile/ProfilePanel.test.jsx
+git commit -m "feat: add ProfilePanel with v1 trust signals"
+```
+
+---
+
+## Task 23: Unified member list on PlaygroupDetail
+
+**Files:**
+- Modify: `frontend/src/pages/PlaygroupDetail.jsx`
+
+Per design D6, the member list becomes a single unified list sorted Organizer-first. Organizer rows have a terracotta avatar ring (3px) and a `<RoleBadge role="organizer" />`; Parent rows have the small "Parent" label and the children line.
+
+- [ ] **Step 1: Locate the current member list rendering**
+
+Run: `grep -n "member" frontend/src/pages/PlaygroupDetail.jsx | head -40`
+
+Identify:
+1. How members are fetched (single query returning creator + joiners, or two separate queries?)
+2. Where they render — the JSX block that currently splits host vs parents.
+
+- [ ] **Step 2: Unify the list**
+
+Replace the split rendering with a single list:
+
+```jsx
+// Inside PlaygroupDetail, after `members` is loaded from supabase:
+const sortedMembers = [...members].sort((a, b) => {
+  // Organizer (creator) first, then parents by name.
+  if (a.membership_role === "creator" && b.membership_role !== "creator") return -1;
+  if (a.membership_role !== "creator" && b.membership_role === "creator") return 1;
+  return (a.first_name ?? "").localeCompare(b.first_name ?? "");
+});
+
+// ...in the JSX:
+<div className="flex flex-col gap-2">
+  {sortedMembers.map((m) => {
+    const isOrganizer = m.membership_role === "creator";
+    return (
+      <button
+        key={m.id}
+        onClick={() => openProfile(m)}
+        className="bg-white rounded-xl border border-cream-dark p-3 flex gap-3 items-center text-left cursor-pointer"
+      >
+        <div
+          className={`w-10 h-10 rounded-full bg-sage-light flex-shrink-0 ${
+            isOrganizer ? "border-[3px] border-terracotta" : ""
+          }`}
+        />
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <div className="font-bold text-sm text-charcoal">
+              {m.first_name} {m.last_name}
+            </div>
+            <RoleBadge role={isOrganizer ? "organizer" : "parent"} />
+          </div>
+          <div className="text-[11px] text-taupe">
+            {isOrganizer ? "Runs the group" : m.children_summary || ""}
+          </div>
+        </div>
+      </button>
+    );
+  })}
+</div>
+```
+
+Add `import RoleBadge from "../components/profile/RoleBadge";` at the top.
+
+- [ ] **Step 3: Wire openProfile to ProfilePanel**
+
+Add local state `const [activeProfile, setActiveProfile] = useState(null);`. `openProfile(m)` sets it; below the main content render:
+
+```jsx
+{activeProfile && (
+  <div
+    onClick={() => setActiveProfile(null)}
+    className="fixed inset-0 bg-black/40 flex items-end z-50"
+  >
+    <div onClick={(e) => e.stopPropagation()} className="w-full">
+      <ProfilePanel profile={activeProfile} onMessage={() => {/* TODO: route to messages */}} />
+    </div>
+  </div>
+)}
+```
+
+Add `import ProfilePanel from "../components/profile/ProfilePanel";` at the top.
+
+- [ ] **Step 4: Manual QA**
+
+Open any playgroup as a Parent. Members render in one list; the Organizer is first with a terracotta ring and Organizer pill. Tapping any member opens the trust panel. Tapping outside closes it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/PlaygroupDetail.jsx
+git commit -m "feat: unified playgroup member list with Organizer-first sort + ProfilePanel sheet"
+```
+
+---
+
+## Task 24: Remove/replace the old `HostCard` if obsolete
+
+**Files:**
+- Inspect: `frontend/src/components/playgroup/HostCard.jsx`
+- If no callers remain after Task 23, delete; otherwise leave it and note the deprecation.
+
+- [ ] **Step 1: Find callers**
+
+Run: `grep -rn "HostCard" frontend/src`
+
+- [ ] **Step 2: Decide**
+
+- If `HostCard` is only imported in `PlaygroupDetail.jsx` and the import was removed in Task 23 → `rm frontend/src/components/playgroup/HostCard.jsx` and remove the import.
+- If it's still used elsewhere → leave it alone. Add a `// DEPRECATED: prefer ProfilePanel. Kept for <caller>.` comment at the top.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -u frontend/src
+git commit -m "chore: clean up HostCard after ProfilePanel migration"
+```
+
+(Skip the commit if nothing changed.)
+
+---
+
+## Task 25: M3 acceptance
+
+- [ ] **Step 1: Full test suite**
+
+Run: `cd frontend && npm test`
+Expected: all green.
+
+- [ ] **Step 2: Manual QA**
+
+1. Parent opens Little Sprouts detail → unified list shows Organizer first with terracotta ring and pill
+2. Tap the Organizer → sheet slides up showing Priya's ProfilePanel with verified check, role label, zip, stat strip, children, about, tags, Message button
+3. Tap a Parent → sheet shows their ProfilePanel with `Parent` label (no Organizer pill), their kids line
+4. Confirm NO tenure, NO rating, NO groups-in-common rendered (deferred signals)
+5. Tap outside the sheet → closes
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+M3 done. Spec complete.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- D1 Two audiences → Tasks 5, 6 (separate layouts with distinct accent + label + nav)
+- D2 Choose once → Tasks 8, 9 (ChooseRole picker + role persistence)
+- D3 Second role deferred → n/a (explicitly out of scope, no task needed)
+- D4 Mode layout wrappers → Tasks 5, 6, 10
+- D5 Signup path picker → Task 8
+- D6 Unified playgroup member list → Task 23
+- D7 Phone OTP → Tasks 13–18
+- D8 Trust signals v1 → Tasks 20–22 (tenure/rating/groups-in-common explicitly asserted as excluded in Task 22 test)
+- D9 Copy renames → Task 11
+- D10 Migration → Task 1
+
+**Placeholder scan:** No "TBD", no "implement later", no "similar to Task N" hand-waves. Every step shows the code or exact command it requires. Twilio secret procurement in Task 14 step 3 is the one external blocker, explicitly called out.
+
+**Type consistency:** `accountType` used in AuthContext (Task 2), `useAccountType` (Task 3), `RequireRole` (Task 4), TabBar (Task 7), Welcome redirect (Task 10), RoleBadge+ProfilePanel+PlaygroupDetail (Tasks 20, 22, 23) — all consistent. `membership_role === "creator"` used for the Organizer-first sort in Task 23 matches the existing DB value. `phone_verified_at` set in edge function (Task 15), read in useSubscription (Task 18) and ProfilePanel (Task 22) — consistent column name.
+
+**Scope:** Three milestones, each shippable on its own. Each ends in a deploy-and-QA step.

--- a/docs/superpowers/specs/2026-04-15-role-identity-and-trust-design.md
+++ b/docs/superpowers/specs/2026-04-15-role-identity-and-trust-design.md
@@ -1,0 +1,265 @@
+# Role Identity & Trust — Design
+
+**Date:** 2026-04-15
+**Status:** Draft for review
+**Scope:** Kiddaboo today, WelbyRise (senior-care reskin) by carry-over
+
+## Problem
+
+A user feedback session surfaced two linked problems:
+
+1. **Role identity is weak.** Hosts and joiners see nearly identical UI. Testers reported (i) not knowing which role they were in, (ii) hosts seeing joiner screens and vice versa, (iii) being unable to tell on a group detail page who was the host vs. a member, and (iv) the context switch between hosting and joining feeling jarring.
+2. **User identity is weak.** Testers struggled to tell who another person was from their profile. Avatars felt generic, real names were inconsistent, and there were no trust signals (no verification, no tenure, no reviews).
+
+These are not cosmetic complaints; for a kids-and-families network, trust is the product. The same problems will apply — with higher stakes — when Kiddaboo is reskinned as WelbyRise, a senior-care companion app. Any fix we make here should be structural enough to survive the reskin.
+
+## Goals
+
+1. A user always knows which role they are acting as.
+2. A user looking at another person in a shared space always knows that person's role.
+3. A user looking at a profile trusts that the person is real and has a plausible reason to be on the network.
+4. The structural work done once applies to both Kiddaboo and WelbyRise; only theme, copy, and domain fields differ between the two products.
+
+## Non-goals
+
+- Redesigning the Kiddaboo color palette, wordmark, or visual style. Those are deferred to the WelbyRise reskin.
+- Multi-role dual-mode accounts. Users choose one role at signup; adding the other role later is out of scope for v1.
+- Deep identity verification (ID upload, background checks). Phone OTP only in v1.
+- Reputation systems beyond what already exists (reviews).
+
+## Terminology
+
+To keep the design portable between the two products we use role placeholders:
+
+| Placeholder | Kiddaboo UI | WelbyRise UI | DB role | Subject of profile |
+|---|---|---|---|---|
+| **Role A** | Organizer | Host | `memberships.role = 'creator'` + `profiles.account_type = 'organizer'` | Themselves |
+| **Role B** | Parent | Family member | `profiles.account_type = 'parent'` (Kiddaboo) or `'family'` (WelbyRise) | Themselves + child(ren) / senior |
+
+Renaming "Host" to "Organizer" in Kiddaboo is intentional. "Host" reads as "hosting-a-party" for a non-tech-savvy audience; "Organizer" reads as "community organizer." For WelbyRise, "Host" is the natural term for someone who visits seniors, so that product keeps it.
+
+## Decisions
+
+### D1 — Two audiences, not one
+
+Role A and Role B users see different products. They have different home screens, different navigation, different dominant actions, and a different accent color. A Role A user cannot accidentally end up on a Role B screen, and vice versa.
+
+### D2 — Choose once, at signup
+
+New users declare their role on the signup landing. The UI uses side-by-side cards with role-noun framing ("I'm a Parent" / "I'm an Organizer"). The choice writes a new `profiles.account_type` column. Existing users are auto-assigned on migration: anyone with a `memberships.role = 'creator'` row becomes `organizer`; everyone else becomes `parent`. On first login after the migration, existing users see a one-time "Is this you?" confirm with the option to switch.
+
+### D3 — Adding a second role is a deliberate, out-of-scope flow
+
+The vast majority of users are either Role A or Role B. For the few who want both, v2 introduces an explicit "Become an Organizer" path from Parent settings (and vice versa) that re-uses the same onboarding. v1 does not support dual-role accounts; a Parent who starts a group and a Host-without-a-family do not exist yet.
+
+### D4 — Mode layout wrappers, not route splits
+
+We do **not** split URL paths into `/parent/*` and `/organizer/*`; existing URLs like `/browse` and `/host-dashboard` stay as-is. Instead:
+
+- Add `ParentLayout` and `OrganizerLayout` React components, each wrapping its own set of routes.
+- Each layout applies an accent color (Parent = sage #5C6B52; Organizer = terracotta #B07A5B), a small uppercase mode label in the header ("PARENT" / "ORGANIZER"), and a role-specific bottom nav (Parent: Browse / My Groups / Messages / Profile; Organizer: My Group / Members / Messages / Profile).
+- Route gates: a Parent hitting `/host-dashboard` is redirected to `/browse`; an Organizer hitting `/browse` is redirected to their dashboard.
+- Admin and shared pages (`/my-profile`, `/premium`, `/admin`) are layout-neutral but still show the correct mode label based on `account_type`.
+
+This choice ships faster than a full route refactor (Approach 1 from brainstorming) and still delivers the perceptual separation the feedback session called for.
+
+### D5 — Signup path picker
+
+The signup landing shows two equally-weighted cards:
+
+- **I'm a Parent** — "Looking for a playgroup for my child" (sage border)
+- **I'm an Organizer** — "Starting or running a playgroup" (terracotta border)
+
+Small footer text: "You can add the other role later." Clicking a card routes to a role-specific onboarding flow (Parent: email + password + zip + add children; Organizer: email + password + zip + group basics).
+
+### D6 — Playgroup detail: unified list, Organizer distinguished
+
+On a playgroup detail page, the member list is a single unified list sorted Organizer-first. The Organizer's row has:
+
+- A terracotta avatar ring (3px, `#B07A5B`)
+- A pill-shaped `Organizer` badge next to the name
+- A short tenure line ("Runs the group")
+
+Parent rows share the same card style but carry a small "Parent" label and the children line ("Jack, age 3"). No more ambiguous identical cards.
+
+### D7 — Phone OTP verification
+
+Phone OTP is the single verification mechanism for v1.
+
+- During onboarding, after basic profile info, we ask for a mobile number and send a 6-digit SMS code.
+- On successful verify, `profiles.phone_verified_at` is set.
+- A `profiles.phone_number` column is added (stored hashed for privacy, plaintext only at verification time).
+- Users who do not verify can still browse but cannot send join requests or be approved as Organizers.
+- The SMS is sent via Twilio (~$0.01 per message). A provider abstraction lets WelbyRise swap to a different provider if desired.
+
+The "Verified parent" / "Verified family" badge renders anywhere the profile is shown when both `phone_verified_at` is set *and* the account has completed the role-specific attestation (has at least one child; has at least one senior).
+
+### D8 — Trust signals in v1
+
+A profile panel (the sheet that slides up when you tap a member in a group) renders, in order:
+
+1. Avatar with a green verified checkmark overlay (if verified)
+2. Real first + last name, required at signup
+3. Small secondary line: "Parent of Maya, 3 & Arjun, 1" (or WelbyRise: "Family of Helen, 78")
+4. "Verified parent" or "Verified family" label (green text)
+5. Role label + neighborhood + distance ("Organizer · Garden City · 0.8 mi away")
+6. Stat strip: # of kids/seniors · # of groups joined (no tenure yet)
+7. Children/seniors card: name + age chips
+8. About / bio free-text
+9. Parenting-style tags (Kiddaboo) or care-focus tags (WelbyRise)
+10. Action buttons: Message (primary), more menu
+
+**Explicitly deferred to v2:**
+- Tenure ("N months on Kiddaboo") — risks making new users look untrusted before the network has critical mass
+- Review rating on the profile stat strip — needs enough reviews to be meaningful
+- Groups in common — nice-to-have social proof, not critical
+
+### D9 — Copy renames across the app
+
+Everywhere a Kiddaboo string currently says "Host" in user-facing UI, it becomes "Organizer":
+
+- Landing page button "Host a Playgroup" → "Organize a Playgroup"
+- Settings row "Upgrade to Host Premium" → "Upgrade to Organizer Premium"
+- Admin Subscriptions filter "Host Premium" → "Organizer Premium"
+- Premium compare table row labels
+- Toast messages, email templates, push notification copy
+
+Database identifiers (`host_premium`, `role = 'creator'`, `joiner`) stay unchanged; this is a strictly user-facing rename.
+
+### D10 — Existing users migration
+
+A single SQL migration adds:
+
+```sql
+ALTER TABLE profiles ADD COLUMN account_type TEXT
+  CHECK (account_type IN ('parent', 'organizer'));
+
+ALTER TABLE profiles ADD COLUMN account_type_confirmed_at TIMESTAMPTZ;
+ALTER TABLE profiles ADD COLUMN phone_number TEXT;
+ALTER TABLE profiles ADD COLUMN phone_verified_at TIMESTAMPTZ;
+
+UPDATE profiles p SET account_type = 'organizer'
+  WHERE EXISTS (
+    SELECT 1 FROM memberships m
+    WHERE m.user_id = p.id AND m.role = 'creator'
+  );
+
+UPDATE profiles SET account_type = 'parent'
+  WHERE account_type IS NULL;
+
+ALTER TABLE profiles ALTER COLUMN account_type SET NOT NULL;
+```
+
+Plus a one-time "Is this you?" modal that renders after login if `profiles.account_type_confirmed_at IS NULL` — user taps "Yes" (sets timestamp) or "I'm actually the other role" (updates `account_type`, sets timestamp).
+
+## Architecture
+
+### Data model changes
+
+- `profiles.account_type` — new NOT NULL TEXT column, enum `parent` | `organizer`
+- `profiles.account_type_confirmed_at` — TIMESTAMPTZ, null until user confirms post-migration
+- `profiles.phone_number` — TEXT, nullable, stores hashed value
+- `profiles.phone_verified_at` — TIMESTAMPTZ, nullable
+
+No changes to `memberships`, `subscriptions`, `playgroups`.
+
+### Frontend structure
+
+```
+src/
+  layouts/
+    ParentLayout.jsx       # sage accent, Parent nav, "PARENT" header label
+    OrganizerLayout.jsx    # terracotta accent, Organizer nav
+    SharedLayout.jsx       # for /my-profile, /premium, /admin
+  pages/
+    onboarding/
+      ChooseRole.jsx        # new landing replacement
+      ParentOnboarding.jsx  # email + zip + children
+      OrganizerOnboarding.jsx  # email + zip + group basics
+      PhoneVerify.jsx       # OTP step, reused from both flows
+    parent/                 # file organization only; URLs stay /browse etc.
+      Browse.jsx            # existing, moved
+      MyGroups.jsx
+    organizer/              # file organization only; URLs stay /host-dashboard etc.
+      HostDashboard.jsx     # existing file name kept; UI copy says "Organizer dashboard"
+  components/
+    ProfilePanel/
+      ProfilePanel.jsx      # redesigned profile panel with trust signals
+      VerifiedBadge.jsx     # new
+      RoleBadge.jsx         # new
+  hooks/
+    useAccountType.js       # reads profiles.account_type, blocks on null
+    usePhoneVerification.js # OTP send/verify
+```
+
+### Routing & access control
+
+- `App.jsx` wraps every authenticated route in a `<ModeRouter>` that reads `account_type` and renders the correct layout.
+- A `<RequireRole role="parent">` wrapper around Parent-only routes redirects Organizers away.
+- Symmetric `<RequireRole role="organizer">` wrapper.
+- `/onboarding/*` routes are public-after-signup and do not require a set `account_type`.
+
+### Phone OTP service
+
+- New Supabase edge function `send-otp` — accepts `{ phone }`, calls Twilio, writes the verification code hash + expiry to a `phone_otp_challenges` table.
+- New edge function `verify-otp` — accepts `{ phone, code }`, validates against the challenge table, writes `profiles.phone_verified_at` and `phone_number` on success.
+- Rate limit: max 3 send attempts per phone per hour; challenge expires in 10 minutes.
+
+## Error handling
+
+- **Account type null after migration:** the one-time confirm modal is mandatory before any other navigation works.
+- **Phone OTP send failure (Twilio down):** user sees a retry button and an offer to skip for now ("verify later from settings"). Skipped users can't send join requests but can browse.
+- **Phone OTP code mismatch:** up to 3 attempts; after 3, the challenge is invalidated and the user must request a new code.
+- **User tries to access wrong-role route:** soft redirect (not a 403) to the correct role's home, with a toast "That page is for Organizers only."
+
+## Testing
+
+- **Unit:** `useAccountType` hook branching logic; `usePhoneVerification` send/verify flows; role-guard component redirect logic.
+- **Integration:** onboarding path picker → Parent flow → children → phone verify → Parent home. Same for Organizer flow.
+- **E2E (Playwright):** happy-path Parent signup, Organizer signup, existing-user migration confirm modal, phone OTP success and failure.
+- **Manual:** visual QA of sage vs terracotta accents, mode label visibility, bottom-nav correctness, profile panel trust signals.
+
+## Implementation decomposition
+
+This spec is one design but three implementation plans, executed in order:
+
+1. **Role identity core** — migration + `account_type` column + layout wrappers + signup path picker + copy renames + one-time confirm modal. Ships the perceptual separation.
+2. **Phone OTP verification** — new `phone_otp_challenges` table, `send-otp` + `verify-otp` edge functions, Twilio integration, onboarding phone step, verified badge rendering.
+3. **Profile panel trust redesign** — restructured `ProfilePanel` with the v1 trust signals, `VerifiedBadge` and `RoleBadge` components, updated playgroup detail member list.
+
+Plans 2 and 3 depend on plan 1 landing first. Each gets its own writing-plans output.
+
+## WelbyRise carry-over
+
+The structural work above (account_type, mode layouts, signup path picker, phone OTP, unified member list, trust signals) applies to WelbyRise verbatim. The reskin to WelbyRise becomes a focused pass over:
+
+- Theme: colors, fonts, logo, wordmark
+- Copy: Organizer → Host; Parent → Family member; playgroup → (TBD — companionship circle / visit / etc.); children → seniors; parenting style → care focus
+- Accessibility uplift: larger base type (18px min), higher contrast for senior-adjacent users
+- Trust signals: same shape, senior-care-specific fields
+- Extra consideration (v2): the senior is the profile subject but not the account holder; profile panel shows senior info with the family member as account owner
+
+None of this re-opens the structural decisions made here.
+
+## Rollout
+
+1. **Land the migration and `account_type` column** behind a feature flag in staging
+2. **Ship layout wrappers** with a small cohort (admins only via a feature flag check)
+3. **Ship onboarding path picker** for new signups only; existing users unaffected
+4. **Ship phone OTP** as opt-in first, then required for join requests
+5. **Flip the feature flag** for all existing users once the confirm-modal copy is ready
+6. **Deprecate legacy "Host" strings** in a single cleanup PR
+7. **Begin WelbyRise reskin** work on a new branch, using this design as the foundation
+
+## Out of scope (for this spec)
+
+- The Stripe price-cache bug ($59.99 vs $79.99) and the k6 orphan subscription are separate tech-debt items, fixed before this work lands.
+- Automated test suite bootstrapping (Vitest + Playwright) is a prerequisite, tracked as its own task.
+- Admin module UX audit — separate effort.
+- The reskin itself (theme, copy, accessibility uplift for WelbyRise) — a separate spec once this design is implemented.
+
+## Open questions
+
+- What's the right copy for the "Is this you?" migration modal? Drafted but not finalized.
+- Twilio vs. alternatives (Vonage, Plivo, SNS) — picking one is an implementation decision, noted here for visibility.
+- Do we also need email verification in v1? Current plan: no, phone OTP is enough. Revisit if fraud becomes a problem.

--- a/docs/superpowers/specs/2026-04-15-role-identity-and-trust-design.md
+++ b/docs/superpowers/specs/2026-04-15-role-identity-and-trust-design.md
@@ -128,36 +128,33 @@ Database identifiers (`host_premium`, `role = 'creator'`, `joiner`) stay unchang
 
 ### D10 — Existing users migration
 
-A single SQL migration adds:
+The app has no production users yet — only a handful of tester accounts (Suresh's `rooblix2000+kN@gmail.com` aliases and any invited testers). That collapses the migration story to a one-time manual cleanup.
 
 ```sql
 ALTER TABLE profiles ADD COLUMN account_type TEXT
-  CHECK (account_type IN ('parent', 'organizer'));
+  CHECK (account_type IN ('parent', 'organizer')) NOT NULL DEFAULT 'parent';
 
-ALTER TABLE profiles ADD COLUMN account_type_confirmed_at TIMESTAMPTZ;
 ALTER TABLE profiles ADD COLUMN phone_number TEXT;
 ALTER TABLE profiles ADD COLUMN phone_verified_at TIMESTAMPTZ;
 
+-- Tester cleanup: tag anyone who has ever created a playgroup as organizer.
 UPDATE profiles p SET account_type = 'organizer'
   WHERE EXISTS (
     SELECT 1 FROM memberships m
     WHERE m.user_id = p.id AND m.role = 'creator'
   );
 
-UPDATE profiles SET account_type = 'parent'
-  WHERE account_type IS NULL;
-
-ALTER TABLE profiles ALTER COLUMN account_type SET NOT NULL;
+-- Drop the default after backfill so new signups MUST pick a role explicitly.
+ALTER TABLE profiles ALTER COLUMN account_type DROP DEFAULT;
 ```
 
-Plus a one-time "Is this you?" modal that renders after login if `profiles.account_type_confirmed_at IS NULL` — user taps "Yes" (sets timestamp) or "I'm actually the other role" (updates `account_type`, sets timestamp).
+No confirm modal, no `account_type_confirmed_at` column, no phased rollout. Any tester who ends up in the wrong mode can be fixed with a single `UPDATE` by hand. New signups after this lands are forced through the path picker and can't avoid declaring a role.
 
 ## Architecture
 
 ### Data model changes
 
-- `profiles.account_type` — new NOT NULL TEXT column, enum `parent` | `organizer`
-- `profiles.account_type_confirmed_at` — TIMESTAMPTZ, null until user confirms post-migration
+- `profiles.account_type` — new NOT NULL TEXT column, enum `parent` | `organizer`; no default after initial backfill
 - `profiles.phone_number` — TEXT, nullable, stores hashed value
 - `profiles.phone_verified_at` — TIMESTAMPTZ, nullable
 
@@ -207,7 +204,6 @@ src/
 
 ## Error handling
 
-- **Account type null after migration:** the one-time confirm modal is mandatory before any other navigation works.
 - **Phone OTP send failure (Twilio down):** user sees a retry button and an offer to skip for now ("verify later from settings"). Skipped users can't send join requests but can browse.
 - **Phone OTP code mismatch:** up to 3 attempts; after 3, the challenge is invalidated and the user must request a new code.
 - **User tries to access wrong-role route:** soft redirect (not a 403) to the correct role's home, with a toast "That page is for Organizers only."
@@ -223,7 +219,7 @@ src/
 
 This spec is one design but three implementation plans, executed in order:
 
-1. **Role identity core** — migration + `account_type` column + layout wrappers + signup path picker + copy renames + one-time confirm modal. Ships the perceptual separation.
+1. **Role identity core** — migration + `account_type` column + layout wrappers + signup path picker + copy renames. Ships the perceptual separation.
 2. **Phone OTP verification** — new `phone_otp_challenges` table, `send-otp` + `verify-otp` edge functions, Twilio integration, onboarding phone step, verified badge rendering.
 3. **Profile panel trust redesign** — restructured `ProfilePanel` with the v1 trust signals, `VerifiedBadge` and `RoleBadge` components, updated playgroup detail member list.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,10 @@ import NotFound from "./pages/NotFound";
 import RequireAuth from "./components/auth/RequireAuth";
 import RequireAdmin from "./components/auth/RequireAdmin";
 import OnboardingOnly from "./components/auth/OnboardingOnly";
+import ParentLayout from "./layouts/ParentLayout";
+import OrganizerLayout from "./layouts/OrganizerLayout";
+import RequireRole from "./components/auth/RequireRole";
+import ChooseRole from "./pages/onboarding/ChooseRole";
 
 export default function App() {
   return (
@@ -43,6 +47,7 @@ export default function App() {
         <HostProvider>
           <Routes>
             {/* Public routes — no auth required */}
+            <Route path="/choose-role" element={<ChooseRole />} />
             <Route path="/" element={<Welcome />} />
             <Route path="/verify" element={<PhoneVerification />} />
             <Route path="/reset-password" element={<ResetPassword />} />
@@ -74,12 +79,12 @@ export default function App() {
             <Route path="/premium" element={<RequireAuth><Premium /></RequireAuth>} />
 
             {/* App pages — requires auth, with tab bar */}
-            <Route path="/browse" element={<RequireAuth><AppLayout><Browse /></AppLayout></RequireAuth>} />
-            <Route path="/my-groups" element={<RequireAuth><AppLayout><MyGroups /></AppLayout></RequireAuth>} />
+            <Route path="/browse" element={<RequireAuth><RequireRole role="parent"><ParentLayout><Browse /></ParentLayout></RequireRole></RequireAuth>} />
+            <Route path="/my-groups" element={<RequireAuth><RequireRole role="parent"><ParentLayout><MyGroups /></ParentLayout></RequireRole></RequireAuth>} />
             <Route path="/messages" element={<RequireAuth><AppLayout><Messages /></AppLayout></RequireAuth>} />
             <Route path="/my-profile" element={<RequireAuth><AppLayout><MyProfile /></AppLayout></RequireAuth>} />
-            <Route path="/host/dashboard" element={<RequireAuth><AppLayout><HostDashboard /></AppLayout></RequireAuth>} />
-            <Route path="/host/insights" element={<RequireAuth><AppLayout><HostInsights /></AppLayout></RequireAuth>} />
+            <Route path="/host/dashboard" element={<RequireAuth><RequireRole role="organizer"><OrganizerLayout><HostDashboard /></OrganizerLayout></RequireRole></RequireAuth>} />
+            <Route path="/host/insights" element={<RequireAuth><RequireRole role="organizer"><OrganizerLayout><HostInsights /></OrganizerLayout></RequireRole></RequireAuth>} />
 
             {/* Admin — requires auth + admin role, no tab bar */}
             <Route path="/admin" element={<RequireAdmin><Admin /></RequireAdmin>} />

--- a/frontend/src/components/auth/OnboardingOnly.jsx
+++ b/frontend/src/components/auth/OnboardingOnly.jsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 
 /**
@@ -10,13 +10,18 @@ import { useAuth } from "../../context/AuthContext";
  * if a logged-in user with a completed profile hits the route directly.
  *
  * Returning users (first_name already set) are sent to /my-profile —
- * the supported edit surface. The first-time signup flow threads
- * `location.state.fromOnboarding = true` through the /profile → /children
- * transition so this guard knows to let them pass.
+ * the supported edit surface.
+ *
+ * In-flight signup has a race: after CreateProfile saves, setProfile()
+ * flushes first_name into context, and OnboardingOnly may re-render at
+ * /profile before the navigate() to /children lands. To survive that
+ * window we gate on a sessionStorage flag set at the very start of the
+ * flow (PhoneVerification) and cleared only at the terminal success
+ * pages (BrowseSuccess, HostSuccess). Nav-state doesn't work here
+ * because it only applies to the destination route, not the source.
  */
 export default function OnboardingOnly({ children }) {
   const { user, profile, loading } = useAuth();
-  const location = useLocation();
 
   if (loading) {
     return (
@@ -30,9 +35,11 @@ export default function OnboardingOnly({ children }) {
     return <Navigate to="/" replace />;
   }
 
-  // In-flight signup: CreateProfile just saved first_name and is routing
-  // the user to the next onboarding step. Don't bounce them out.
-  if (location.state?.fromOnboarding) {
+  // In-flight signup: let through until the flow completes.
+  const onboardingActive =
+    typeof window !== "undefined" &&
+    sessionStorage.getItem("kiddaboo.onboardingActive") === "1";
+  if (onboardingActive) {
     return children;
   }
 

--- a/frontend/src/components/auth/OnboardingOnly.jsx
+++ b/frontend/src/components/auth/OnboardingOnly.jsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 
 /**
@@ -9,11 +9,14 @@ import { useAuth } from "../../context/AuthContext";
  * child. That's intentional for first-time onboarding, but devastating
  * if a logged-in user with a completed profile hits the route directly.
  *
- * This wrapper sends anyone who already has a `first_name` on their
- * profile to /my-profile, which is the supported edit surface.
+ * Returning users (first_name already set) are sent to /my-profile —
+ * the supported edit surface. The first-time signup flow threads
+ * `location.state.fromOnboarding = true` through the /profile → /children
+ * transition so this guard knows to let them pass.
  */
 export default function OnboardingOnly({ children }) {
   const { user, profile, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -25,6 +28,12 @@ export default function OnboardingOnly({ children }) {
 
   if (!user) {
     return <Navigate to="/" replace />;
+  }
+
+  // In-flight signup: CreateProfile just saved first_name and is routing
+  // the user to the next onboarding step. Don't bounce them out.
+  if (location.state?.fromOnboarding) {
+    return children;
   }
 
   if (profile?.first_name) {

--- a/frontend/src/components/auth/OnboardingOnly.test.jsx
+++ b/frontend/src/components/auth/OnboardingOnly.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { vi, describe, test, expect } from "vitest";
+import { vi, describe, test, expect, beforeEach } from "vitest";
 import OnboardingOnly from "./OnboardingOnly";
 
 vi.mock("../../context/AuthContext", () => ({
@@ -26,7 +26,11 @@ function renderWithRoute(initialEntries) {
 }
 
 describe("OnboardingOnly", () => {
-  test("redirects to /my-profile when user has first_name and no onboarding state", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test("redirects to /my-profile when user has first_name and onboarding flag not set", () => {
     useAuth.mockReturnValue({
       user: { id: "u1" },
       profile: { first_name: "Jane" },
@@ -36,13 +40,14 @@ describe("OnboardingOnly", () => {
     expect(screen.getByText("My Profile page")).toBeInTheDocument();
   });
 
-  test("lets through when user has first_name but fromOnboarding state is set", () => {
+  test("lets through when user has first_name but onboardingActive flag is set", () => {
+    sessionStorage.setItem("kiddaboo.onboardingActive", "1");
     useAuth.mockReturnValue({
       user: { id: "u1" },
       profile: { first_name: "Jane" },
       loading: false,
     });
-    renderWithRoute([{ pathname: "/children", state: { fromOnboarding: true } }]);
+    renderWithRoute([{ pathname: "/children" }]);
     expect(screen.getByText("AddChildren content")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/auth/OnboardingOnly.test.jsx
+++ b/frontend/src/components/auth/OnboardingOnly.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { vi, describe, test, expect } from "vitest";
+import OnboardingOnly from "./OnboardingOnly";
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from "../../context/AuthContext";
+
+function renderWithRoute(initialEntries) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/children" element={
+          <OnboardingOnly>
+            <div>AddChildren content</div>
+          </OnboardingOnly>
+        } />
+        <Route path="/my-profile" element={<div>My Profile page</div>} />
+        <Route path="/" element={<div>Welcome page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("OnboardingOnly", () => {
+  test("redirects to /my-profile when user has first_name and no onboarding state", () => {
+    useAuth.mockReturnValue({
+      user: { id: "u1" },
+      profile: { first_name: "Jane" },
+      loading: false,
+    });
+    renderWithRoute([{ pathname: "/children" }]);
+    expect(screen.getByText("My Profile page")).toBeInTheDocument();
+  });
+
+  test("lets through when user has first_name but fromOnboarding state is set", () => {
+    useAuth.mockReturnValue({
+      user: { id: "u1" },
+      profile: { first_name: "Jane" },
+      loading: false,
+    });
+    renderWithRoute([{ pathname: "/children", state: { fromOnboarding: true } }]);
+    expect(screen.getByText("AddChildren content")).toBeInTheDocument();
+  });
+
+  test("lets through when user has no first_name (first-time user)", () => {
+    useAuth.mockReturnValue({
+      user: { id: "u1" },
+      profile: { first_name: null },
+      loading: false,
+    });
+    renderWithRoute([{ pathname: "/children" }]);
+    expect(screen.getByText("AddChildren content")).toBeInTheDocument();
+  });
+
+  test("redirects to / when not authenticated", () => {
+    useAuth.mockReturnValue({
+      user: null,
+      profile: null,
+      loading: false,
+    });
+    renderWithRoute([{ pathname: "/children" }]);
+    expect(screen.getByText("Welcome page")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auth/RequireRole.jsx
+++ b/frontend/src/components/auth/RequireRole.jsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import { useAccountType } from "../../hooks/useAccountType";
+
+const HOME_FOR = {
+  parent: "/browse",
+  organizer: "/host/dashboard",
+};
+
+/**
+ * Blocks a route so only the given role can see it. If a user with the
+ * wrong role hits this route, they are bounced to their own home. If
+ * accountType is still loading we render nothing (the global splash
+ * from RequireAuth already covers that case).
+ */
+export default function RequireRole({ role, children }) {
+  const { accountType, loading } = useAccountType();
+  if (loading) return null;
+  if (accountType !== role) {
+    return <Navigate to={HOME_FOR[accountType] || "/"} replace />;
+  }
+  return children;
+}

--- a/frontend/src/components/auth/RequireRole.test.jsx
+++ b/frontend/src/components/auth/RequireRole.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import RequireRole from "./RequireRole";
+import { vi } from "vitest";
+
+vi.mock("../../hooks/useAccountType", () => ({ useAccountType: vi.fn() }));
+import { useAccountType } from "../../hooks/useAccountType";
+
+function renderAt(initial, role) {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <Routes>
+        <Route path="/browse" element={<RequireRole role={role}><div>browse-content</div></RequireRole>} />
+        <Route path="/host/dashboard" element={<div>dashboard-content</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test("renders children when role matches", () => {
+  useAccountType.mockReturnValue({ accountType: "parent", isParent: true, isOrganizer: false, loading: false });
+  renderAt("/browse", "parent");
+  expect(screen.getByText("browse-content")).toBeInTheDocument();
+});
+
+test("redirects organizers away from parent routes", () => {
+  useAccountType.mockReturnValue({ accountType: "organizer", isParent: false, isOrganizer: true, loading: false });
+  renderAt("/browse", "parent");
+  expect(screen.getByText("dashboard-content")).toBeInTheDocument();
+});
+
+test("shows loading state while accountType is resolving", () => {
+  useAccountType.mockReturnValue({ accountType: null, isParent: false, isOrganizer: false, loading: true });
+  renderAt("/browse", "parent");
+  expect(screen.queryByText("browse-content")).not.toBeInTheDocument();
+  expect(screen.queryByText("dashboard-content")).not.toBeInTheDocument();
+});

--- a/frontend/src/components/layout/TabBar.jsx
+++ b/frontend/src/components/layout/TabBar.jsx
@@ -191,7 +191,7 @@ export default function TabBar({ badges = {} }) {
   const TABS = accountType === "organizer" ? ORGANIZER_TABS : PARENT_TABS;
 
   return (
-    <nav aria-label="Main navigation" className="sticky bottom-0 z-30 bg-cream/95 backdrop-blur-sm border-t border-cream-dark pb-[env(safe-area-inset-bottom)]">
+    <nav aria-label="Main navigation" className="sticky bottom-0 z-30 bg-white border-t border-cream-dark shadow-[0_-2px_8px_rgba(0,0,0,0.04)] pb-[env(safe-area-inset-bottom)]">
       <div className="max-w-md mx-auto flex items-center justify-around px-2 pt-2 pb-1">
         {TABS.map((tab) => {
           const isActive = tab.matchPaths
@@ -210,7 +210,7 @@ export default function TabBar({ badges = {} }) {
                 flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl
                 transition-colors duration-150 cursor-pointer
                 bg-transparent border-none min-w-[60px] relative
-                ${isActive ? "text-sage-dark" : "text-taupe/50 hover:text-taupe"}
+                ${isActive ? "text-sage-dark" : "text-taupe hover:text-taupe-dark"}
               `}
             >
               <div className="relative">
@@ -223,7 +223,7 @@ export default function TabBar({ badges = {} }) {
               </div>
               <span
                 className={`text-[10px] font-medium ${
-                  isActive ? "text-sage-dark" : "text-taupe/50"
+                  isActive ? "text-sage-dark" : "text-taupe"
                 }`}
               >
                 {tab.label}
@@ -234,14 +234,14 @@ export default function TabBar({ badges = {} }) {
         <button
           onClick={async () => { await signOut(); navigate("/"); }}
           aria-label="Sign out"
-          className="flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl transition-colors duration-150 cursor-pointer bg-transparent border-none min-w-[60px] text-taupe/50 hover:text-taupe"
+          className="flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl transition-colors duration-150 cursor-pointer bg-transparent border-none min-w-[60px] text-taupe hover:text-taupe-dark"
         >
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
             <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
             <polyline points="16 17 21 12 16 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
             <line x1="21" y1="12" x2="9" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
-          <span className="text-[10px] font-medium text-taupe/50">Sign out</span>
+          <span className="text-[10px] font-medium text-taupe">Sign out</span>
         </button>
       </div>
     </nav>

--- a/frontend/src/components/layout/TabBar.jsx
+++ b/frontend/src/components/layout/TabBar.jsx
@@ -172,14 +172,14 @@ const PARENT_TABS = [
   { path: "/my-profile", label: "Profile", icon: ProfileIcon },
 ];
 
-const HOST_TABS = [
+const ORGANIZER_TABS = [
   {
     path: "/host/dashboard",
     matchPaths: ["/host/dashboard", "/my-groups"],
-    label: "Dashboard",
+    label: "My Group",
     icon: DashboardIcon,
   },
-  { path: "/host/insights", label: "Insights", icon: InsightsIcon },
+  { path: "/host/insights", label: "Members", icon: InsightsIcon },
   { path: "/messages", label: "Messages", icon: MessagesIcon },
   { path: "/my-profile", label: "Profile", icon: ProfileIcon },
 ];
@@ -187,8 +187,8 @@ const HOST_TABS = [
 export default function TabBar({ badges = {} }) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { signOut, isHost } = useAuth();
-  const TABS = isHost ? HOST_TABS : PARENT_TABS;
+  const { signOut, accountType } = useAuth();
+  const TABS = accountType === "organizer" ? ORGANIZER_TABS : PARENT_TABS;
 
   return (
     <nav aria-label="Main navigation" className="sticky bottom-0 z-30 bg-cream/95 backdrop-blur-sm border-t border-cream-dark pb-[env(safe-area-inset-bottom)]">

--- a/frontend/src/components/layout/TabBar.test.jsx
+++ b/frontend/src/components/layout/TabBar.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TabBar from "./TabBar";
+import { vi } from "vitest";
+
+vi.mock("../../context/AuthContext");
+import { useAuth } from "../../context/AuthContext";
+
+const setAuth = (accountType) =>
+  useAuth.mockReturnValue({
+    signOut: vi.fn(),
+    isHost: accountType === "organizer",
+    accountType,
+  });
+
+test("parent sees Browse / My Groups / Messages / Profile", () => {
+  setAuth("parent");
+  render(<MemoryRouter><TabBar /></MemoryRouter>);
+  expect(screen.getByLabelText("Browse")).toBeInTheDocument();
+  expect(screen.getByLabelText("My Groups")).toBeInTheDocument();
+  expect(screen.queryByLabelText("My Group")).not.toBeInTheDocument();
+});
+
+test("organizer sees My Group / Members / Messages / Profile", () => {
+  setAuth("organizer");
+  render(<MemoryRouter><TabBar /></MemoryRouter>);
+  expect(screen.getByLabelText("My Group")).toBeInTheDocument();
+  expect(screen.getByLabelText("Members")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Browse")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Dashboard")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Insights")).not.toBeInTheDocument();
+});

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }) {
   const fetchProfile = async (userId) => {
     const { data, error } = await supabase
       .from("profiles")
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role, account_type")
       .eq("id", userId)
       .single();
 
@@ -108,7 +108,7 @@ export function AuthProvider({ children }) {
       .from("profiles")
       .update({ ...updates, updated_at: new Date().toISOString() })
       .eq("id", user.id)
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role, account_type")
       .single();
 
     if (error) {
@@ -130,6 +130,7 @@ export function AuthProvider({ children }) {
         loading,
         isAdmin,
         isHost,
+        accountType: profile?.account_type ?? null,
         refreshHostStatus,
         signUp,
         signIn,

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -17,13 +17,16 @@ test("AuthContext exposes accountType from the profiles row", async () => {
   supabase.auth.onAuthStateChange.mockReturnValue({
     data: { subscription: { unsubscribe: vi.fn() } },
   });
+  // Mock covers both fetchProfile (profiles select → eq → single) and
+  // fetchHostStatus (memberships select → eq → eq → limit). Each .eq()
+  // returns the same chain so either call shape resolves cleanly.
+  const eqChain = {
+    single: () => Promise.resolve({ data: { id: "u1", first_name: "A", account_type: "organizer" }, error: null }),
+    limit: () => Promise.resolve({ data: [], error: null }),
+  };
+  eqChain.eq = () => eqChain;
   supabase.from.mockReturnValue({
-    select: () => ({
-      eq: () => ({
-        single: () => Promise.resolve({ data: { id: "u1", first_name: "A", account_type: "organizer" }, error: null }),
-        limit: () => Promise.resolve({ data: [], error: null }),
-      }),
-    }),
+    select: () => ({ eq: () => eqChain }),
   });
 
   render(

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./AuthContext";
+import { supabase } from "../lib/supabase";
+import { vi } from "vitest";
+
+vi.mock("../lib/supabase");
+
+function Probe() {
+  const { accountType, loading } = useAuth();
+  return <div>type={loading ? "…" : accountType ?? "null"}</div>;
+}
+
+test("AuthContext exposes accountType from the profiles row", async () => {
+  supabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: "u1" } } },
+  });
+  supabase.auth.onAuthStateChange.mockReturnValue({
+    data: { subscription: { unsubscribe: vi.fn() } },
+  });
+  supabase.from.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        single: () => Promise.resolve({ data: { id: "u1", first_name: "A", account_type: "organizer" }, error: null }),
+        limit: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
+  });
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  await waitFor(() => expect(screen.getByText("type=organizer")).toBeInTheDocument());
+});

--- a/frontend/src/hooks/useAccountType.js
+++ b/frontend/src/hooks/useAccountType.js
@@ -1,0 +1,16 @@
+import { useAuth } from "../context/AuthContext";
+
+/**
+ * Thin accessor over AuthContext.accountType. Prefer this over reading
+ * profile.account_type directly so we have one seam to swap if the
+ * source of truth ever moves (e.g., into a JWT claim).
+ */
+export function useAccountType() {
+  const { accountType, loading } = useAuth();
+  return {
+    accountType,
+    isParent: accountType === "parent",
+    isOrganizer: accountType === "organizer",
+    loading,
+  };
+}

--- a/frontend/src/hooks/useAccountType.test.jsx
+++ b/frontend/src/hooks/useAccountType.test.jsx
@@ -1,0 +1,27 @@
+import { renderHook } from "@testing-library/react";
+import { useAccountType } from "./useAccountType";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+import { useAuth } from "../context/AuthContext";
+
+test("returns parent/organizer booleans", () => {
+  useAuth.mockReturnValue({ accountType: "organizer", loading: false });
+  const { result } = renderHook(() => useAccountType());
+  expect(result.current).toEqual({
+    accountType: "organizer",
+    isParent: false,
+    isOrganizer: true,
+    loading: false,
+  });
+});
+
+test("returns null+false+false while loading", () => {
+  useAuth.mockReturnValue({ accountType: null, loading: true });
+  const { result } = renderHook(() => useAccountType());
+  expect(result.current.isParent).toBe(false);
+  expect(result.current.isOrganizer).toBe(false);
+  expect(result.current.loading).toBe(true);
+});

--- a/frontend/src/layouts/OrganizerLayout.jsx
+++ b/frontend/src/layouts/OrganizerLayout.jsx
@@ -1,0 +1,24 @@
+import TabBar from "../components/layout/TabBar";
+
+/**
+ * Organizer-mode wrapper. Terracotta accent, "ORGANIZER" label, and
+ * warmer background so the mode feels visually different from Parent.
+ * We scope the accent with data-mode="organizer" so individual pages
+ * can opt into mode-aware styling via CSS attribute selectors if they
+ * want (e.g., buttons that read from [data-mode=organizer] .btn).
+ */
+export default function OrganizerLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-[#F9F4ED] flex flex-col" data-mode="organizer">
+      <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
+        <div className="px-5 pt-3">
+          <span className="text-[10px] font-bold tracking-[1.5px] text-terracotta uppercase">
+            Organizer
+          </span>
+        </div>
+        <div className="flex-1">{children}</div>
+        <TabBar />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/OrganizerLayout.test.jsx
+++ b/frontend/src/layouts/OrganizerLayout.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import OrganizerLayout from "./OrganizerLayout";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ signOut: vi.fn(), accountType: "organizer" }),
+}));
+
+test("shows ORGANIZER mode label with terracotta tint and renders children", () => {
+  render(
+    <MemoryRouter>
+      <OrganizerLayout><div>child</div></OrganizerLayout>
+    </MemoryRouter>
+  );
+  const label = screen.getByText("Organizer");
+  expect(label).toBeInTheDocument();
+  expect(label.className).toMatch(/terracotta/);
+  expect(screen.getByText("child")).toBeInTheDocument();
+});

--- a/frontend/src/layouts/ParentLayout.jsx
+++ b/frontend/src/layouts/ParentLayout.jsx
@@ -1,0 +1,26 @@
+import TabBar from "../components/layout/TabBar";
+
+/**
+ * Parent-mode wrapper. Adds the small uppercase "PARENT" label at the
+ * top of the page and reserves space for the bottom TabBar. We rely on
+ * TabBar to pick the correct tabs via accountType (Task 7 wires that).
+ *
+ * Accent color (sage #5C6B52) is already the global default in
+ * Kiddaboo, so there's nothing to override here. OrganizerLayout
+ * does the accent overriding.
+ */
+export default function ParentLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-cream flex flex-col" data-mode="parent">
+      <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
+        <div className="px-5 pt-3">
+          <span className="text-[10px] font-bold tracking-[1.5px] text-sage-dark uppercase">
+            Parent
+          </span>
+        </div>
+        <div className="flex-1">{children}</div>
+        <TabBar />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/ParentLayout.test.jsx
+++ b/frontend/src/layouts/ParentLayout.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ParentLayout from "./ParentLayout";
+import { vi } from "vitest";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ signOut: vi.fn(), accountType: "parent" }),
+}));
+
+test("shows PARENT mode label and renders children", () => {
+  render(
+    <MemoryRouter>
+      <ParentLayout><div>child</div></ParentLayout>
+    </MemoryRouter>
+  );
+  expect(screen.getByText("Parent")).toBeInTheDocument();
+  expect(screen.getByText("child")).toBeInTheDocument();
+});

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -221,7 +221,7 @@ export default function Browse() {
               </h1>
               {profile?.first_name && (
                 <span className="text-sm font-medium text-taupe truncate">
-                  Hi, {profile.first_name}{isHost ? " (Host)" : ""}
+                  Hi, {profile.first_name}{isHost ? " (Organizer)" : ""}
                 </span>
               )}
             </div>

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -479,7 +479,7 @@ export default function Browse() {
                   onClick={() => navigate("/host/create")}
                   className="bg-sage text-white font-medium text-sm rounded-2xl px-6 py-3 cursor-pointer border-none hover:bg-sage-dark transition-colors"
                 >
-                  Host a Playgroup
+                  Organize a Playgroup
                 </button>
               </>
             )}

--- a/frontend/src/pages/BrowseSuccess.jsx
+++ b/frontend/src/pages/BrowseSuccess.jsx
@@ -60,6 +60,14 @@ export default function BrowseSuccess() {
   const { data } = useOnboarding();
   const [playgroups, setPlaygroups] = useState([]);
 
+  // Terminal state for the parent signup flow — clear the onboarding
+  // flag so OnboardingOnly will correctly bounce future /profile or
+  // /children visits to /my-profile instead of letting them destroy
+  // the saved profile.
+  useEffect(() => {
+    sessionStorage.removeItem("kiddaboo.onboardingActive");
+  }, []);
+
   useEffect(() => {
     const fetchPlaygroups = async () => {
       const { data: pgs } = await supabase

--- a/frontend/src/pages/CreateProfile.jsx
+++ b/frontend/src/pages/CreateProfile.jsx
@@ -83,7 +83,10 @@ export default function CreateProfile() {
       }
 
       sessionStorage.removeItem("kiddaboo.pendingAccountType");
-      navigate(pendingAccountType === "organizer" ? "/host/create" : "/children");
+      navigate(
+        pendingAccountType === "organizer" ? "/host/create" : "/children",
+        { state: { fromOnboarding: true } }
+      );
     }
   };
 

--- a/frontend/src/pages/CreateProfile.jsx
+++ b/frontend/src/pages/CreateProfile.jsx
@@ -17,6 +17,14 @@ export default function CreateProfile() {
   const [saving, setSaving] = useState(false);
   const [photoFile, setPhotoFile] = useState(null);
 
+  // Read role once on mount — determines which voice the copy uses.
+  // Missing value falls back to parent framing; handleContinue has a
+  // fail-closed guard that bounces the user back to /choose-role on save.
+  const [pendingAccountType] = useState(() =>
+    sessionStorage.getItem("kiddaboo.pendingAccountType")
+  );
+  const isOrganizer = pendingAccountType === "organizer";
+
   const handlePhotoChange = (e) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -37,7 +45,6 @@ export default function CreateProfile() {
       // send the user back to pick one. The ChooseRole page is the
       // only authorized entry into signup, so we should never get
       // here without it — but guard anyway.
-      const pendingAccountType = sessionStorage.getItem("kiddaboo.pendingAccountType");
       if (pendingAccountType !== "parent" && pendingAccountType !== "organizer") {
         navigate("/choose-role");
         return;
@@ -97,7 +104,9 @@ export default function CreateProfile() {
             Tell us about you
           </h1>
           <p className="text-taupe leading-relaxed">
-            Other moms will see this when you request to join a playgroup.
+            {isOrganizer
+              ? "Parents will see this when they consider joining your playgroup."
+              : "Other families will see this when you request to join a playgroup."}
           </p>
         </div>
 
@@ -131,7 +140,9 @@ export default function CreateProfile() {
             </p>
             {/* #58: trust microcopy — parents worry about photo visibility */}
             <p className="text-[11px] text-taupe/50 text-center mt-1">
-              Only shown to hosts and members of groups you join. Never public.
+              {isOrganizer
+                ? "Shown to parents considering your playgroup. Helps build trust."
+                : "Only shown to organizers and members of groups you join. Never public."}
             </p>
           </label>
         </div>
@@ -153,27 +164,36 @@ export default function CreateProfile() {
           />
         </div>
 
-        {/* Zip code */}
-        <Input
-          label="Zip code"
-          value={data.zipCode}
-          onChange={(val) => updateField("zipCode", val.replace(/[^0-9-]/g, "").slice(0, 10))}
-          placeholder="60640"
-          error={errors.zipCode}
-        />
-        <p className="text-[11px] text-taupe/50 -mt-4">
-          Helps us show you playgroups nearby. Never shared publicly.
-        </p>
+        {/* Zip code — parent only. Organizers set their playgroup
+            location in /host/create, so asking here is noise. */}
+        {!isOrganizer && (
+          <>
+            <Input
+              label="Zip code"
+              value={data.zipCode}
+              onChange={(val) => updateField("zipCode", val.replace(/[^0-9-]/g, "").slice(0, 10))}
+              placeholder="60640"
+              error={errors.zipCode}
+            />
+            <p className="text-[11px] text-taupe/50 -mt-4">
+              Helps us show you playgroups nearby. Never shared publicly.
+            </p>
+          </>
+        )}
 
         {/* Bio */}
         <div className="flex flex-col gap-1.5">
           <label className="text-sm font-medium text-taupe">
-            About you & your family
+            {isOrganizer ? "About you" : "About you & your family"}
           </label>
           <textarea
             value={data.bio}
             onChange={(e) => updateField("bio", e.target.value)}
-            placeholder="A little about your family, your values, and what you're looking for in a playgroup..."
+            placeholder={
+              isOrganizer
+                ? "Why you're starting this playgroup, your experience with kids, what parents should know about you..."
+                : "A little about your family, your values, and what you're looking for in a playgroup..."
+            }
             maxLength={200}
             rows={3}
             className="
@@ -188,14 +208,19 @@ export default function CreateProfile() {
           </span>
         </div>
 
-        {/* Philosophy tags */}
-        <TagSelector
-          label="Parenting philosophy"
-          options={PHILOSOPHY_TAGS}
-          selected={data.philosophyTags}
-          onChange={(tags) => updateField("philosophyTags", tags)}
-          maxSelections={4}
-        />
+        {/* Philosophy tags — parent only. These are parenting styles
+            parents use to find a compatible playgroup; organizers
+            describe their group's philosophy on the playgroup itself
+            in /host/create. */}
+        {!isOrganizer && (
+          <TagSelector
+            label="Parenting philosophy"
+            options={PHILOSOPHY_TAGS}
+            selected={data.philosophyTags}
+            onChange={(tags) => updateField("philosophyTags", tags)}
+            maxSelections={4}
+          />
+        )}
 
         {errors.save && (
           <p className="text-sm text-red-500">{errors.save}</p>

--- a/frontend/src/pages/CreateProfile.jsx
+++ b/frontend/src/pages/CreateProfile.jsx
@@ -33,6 +33,16 @@ export default function CreateProfile() {
     setErrors(newErrors);
 
     if (Object.keys(newErrors).length === 0) {
+      // Fail closed: if ChooseRole wasn't visited (no stashed role),
+      // send the user back to pick one. The ChooseRole page is the
+      // only authorized entry into signup, so we should never get
+      // here without it — but guard anyway.
+      const pendingAccountType = sessionStorage.getItem("kiddaboo.pendingAccountType");
+      if (pendingAccountType !== "parent" && pendingAccountType !== "organizer") {
+        navigate("/choose-role");
+        return;
+      }
+
       setSaving(true);
 
       // Upload profile photo if selected
@@ -58,6 +68,7 @@ export default function CreateProfile() {
         bio: data.bio.trim(),
         philosophy_tags: data.philosophyTags,
         zip_code: data.zipCode.trim() || null,
+        account_type: pendingAccountType,
       };
       if (photoUrl) profileData.photo_url = photoUrl;
 
@@ -71,7 +82,8 @@ export default function CreateProfile() {
         return;
       }
 
-      navigate("/children");
+      sessionStorage.removeItem("kiddaboo.pendingAccountType");
+      navigate(pendingAccountType === "organizer" ? "/host/create" : "/children");
     }
   };
 

--- a/frontend/src/pages/CreateProfile.jsx
+++ b/frontend/src/pages/CreateProfile.jsx
@@ -84,8 +84,7 @@ export default function CreateProfile() {
 
       sessionStorage.removeItem("kiddaboo.pendingAccountType");
       navigate(
-        pendingAccountType === "organizer" ? "/host/create" : "/children",
-        { state: { fromOnboarding: true } }
+        pendingAccountType === "organizer" ? "/host/create" : "/children"
       );
     }
   };

--- a/frontend/src/pages/CreateProfile.role-routing.test.jsx
+++ b/frontend/src/pages/CreateProfile.role-routing.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import CreateProfile from "./CreateProfile";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => ({
+  ...(await vi.importActual("react-router-dom")),
+  useNavigate: () => navigate,
+}));
+
+const updateProfile = vi.fn().mockResolvedValue({ error: null });
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "u1" }, updateProfile }),
+}));
+
+vi.mock("../context/OnboardingContext", () => ({
+  useOnboarding: () => ({
+    data: {
+      photoUrl: "blob:existing",
+      firstName: "Pat",
+      lastName: "Parent",
+      bio: "",
+      philosophyTags: [],
+      zipCode: "11530",
+    },
+    updateField: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  navigate.mockClear();
+  updateProfile.mockClear();
+  sessionStorage.clear();
+});
+
+test("routes parent to /children after save and writes account_type=parent", async () => {
+  sessionStorage.setItem("kiddaboo.pendingAccountType", "parent");
+  render(<MemoryRouter><CreateProfile /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+  await waitFor(() => expect(updateProfile).toHaveBeenCalled());
+  expect(updateProfile.mock.calls[0][0].account_type).toBe("parent");
+  expect(navigate).toHaveBeenCalledWith("/children");
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
+});
+
+test("routes organizer to /host/create after save and writes account_type=organizer", async () => {
+  sessionStorage.setItem("kiddaboo.pendingAccountType", "organizer");
+  render(<MemoryRouter><CreateProfile /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+  await waitFor(() => expect(updateProfile).toHaveBeenCalled());
+  expect(updateProfile.mock.calls[0][0].account_type).toBe("organizer");
+  expect(navigate).toHaveBeenCalledWith("/host/create");
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
+});
+
+test("bounces back to /choose-role if no stashed role", async () => {
+  render(<MemoryRouter><CreateProfile /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+  await waitFor(() => expect(navigate).toHaveBeenCalledWith("/choose-role"));
+  expect(updateProfile).not.toHaveBeenCalled();
+});

--- a/frontend/src/pages/CreateProfile.role-routing.test.jsx
+++ b/frontend/src/pages/CreateProfile.role-routing.test.jsx
@@ -40,7 +40,7 @@ test("routes parent to /children after save and writes account_type=parent", asy
   fireEvent.click(screen.getByRole("button", { name: /continue/i }));
   await waitFor(() => expect(updateProfile).toHaveBeenCalled());
   expect(updateProfile.mock.calls[0][0].account_type).toBe("parent");
-  expect(navigate).toHaveBeenCalledWith("/children", { state: { fromOnboarding: true } });
+  expect(navigate).toHaveBeenCalledWith("/children");
   expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
 });
 
@@ -50,7 +50,7 @@ test("routes organizer to /host/create after save and writes account_type=organi
   fireEvent.click(screen.getByRole("button", { name: /continue/i }));
   await waitFor(() => expect(updateProfile).toHaveBeenCalled());
   expect(updateProfile.mock.calls[0][0].account_type).toBe("organizer");
-  expect(navigate).toHaveBeenCalledWith("/host/create", { state: { fromOnboarding: true } });
+  expect(navigate).toHaveBeenCalledWith("/host/create");
   expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
 });
 

--- a/frontend/src/pages/CreateProfile.role-routing.test.jsx
+++ b/frontend/src/pages/CreateProfile.role-routing.test.jsx
@@ -40,7 +40,7 @@ test("routes parent to /children after save and writes account_type=parent", asy
   fireEvent.click(screen.getByRole("button", { name: /continue/i }));
   await waitFor(() => expect(updateProfile).toHaveBeenCalled());
   expect(updateProfile.mock.calls[0][0].account_type).toBe("parent");
-  expect(navigate).toHaveBeenCalledWith("/children");
+  expect(navigate).toHaveBeenCalledWith("/children", { state: { fromOnboarding: true } });
   expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
 });
 
@@ -50,7 +50,7 @@ test("routes organizer to /host/create after save and writes account_type=organi
   fireEvent.click(screen.getByRole("button", { name: /continue/i }));
   await waitFor(() => expect(updateProfile).toHaveBeenCalled());
   expect(updateProfile.mock.calls[0][0].account_type).toBe("organizer");
-  expect(navigate).toHaveBeenCalledWith("/host/create");
+  expect(navigate).toHaveBeenCalledWith("/host/create", { state: { fromOnboarding: true } });
   expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
 });
 

--- a/frontend/src/pages/MyGroups.jsx
+++ b/frontend/src/pages/MyGroups.jsx
@@ -257,7 +257,7 @@ export default function MyGroups() {
                 </div>
                 <div className="text-left">
                   <h3 className="font-heading font-bold text-charcoal text-sm">
-                    Host a Playgroup
+                    Organize a Playgroup
                   </h3>
                   <p className="text-xs text-taupe mt-0.5">
                     Create your own curated group for families in your area

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -90,7 +90,7 @@ export default function MyProfile() {
             isHost
               ? {
                   icon: "\u2b50",
-                  label: isHostPremium ? "Host Premium Member" : "Upgrade to Host Premium",
+                  label: isHostPremium ? "Organizer Premium Member" : "Upgrade to Organizer Premium",
                   sublabel: isHostPremium ? null : "Priority placement, view analytics & more",
                   path: "/host/premium",
                   highlight: true,

--- a/frontend/src/pages/PhoneVerification.jsx
+++ b/frontend/src/pages/PhoneVerification.jsx
@@ -90,6 +90,14 @@ export default function PhoneVerification() {
             .limit(1),
         ]);
 
+        // Returning-user sign-in is a terminal state for the onboarding
+        // flag: if it was set by a stray /verify?role=X visit before the
+        // user toggled to Sign In, don't let it leak into OnboardingOnly
+        // and let them destroy their saved profile later.
+        if (prof?.first_name) {
+          sessionStorage.removeItem("kiddaboo.onboardingActive");
+        }
+
         if (!prof?.first_name) {
           navigate("/profile");
         } else if (hostMemberships && hostMemberships.length > 0) {

--- a/frontend/src/pages/PhoneVerification.jsx
+++ b/frontend/src/pages/PhoneVerification.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import OnboardingLayout from "../components/layout/OnboardingLayout";
 import Input from "../components/ui/Input";
@@ -20,6 +20,19 @@ export default function PhoneVerification() {
   const [checkEmail, setCheckEmail] = useState(false);
   const [resetSent, setResetSent] = useState(false);
   const [resetLoading, setResetLoading] = useState(false);
+
+  // Stash the role chosen on /choose-role so it survives the email-
+  // confirmation round-trip and is available to CreateProfile after
+  // signup. Only accept the two valid values — never trust whatever
+  // else someone puts in the query string. Don't overwrite an
+  // existing stash if the param is absent (preserves the value if
+  // the user navigates back and forth).
+  useEffect(() => {
+    const role = searchParams.get("role");
+    if (role === "parent" || role === "organizer") {
+      sessionStorage.setItem("kiddaboo.pendingAccountType", role);
+    }
+  }, [searchParams]);
 
   const handleSubmit = async () => {
     setError("");

--- a/frontend/src/pages/PhoneVerification.jsx
+++ b/frontend/src/pages/PhoneVerification.jsx
@@ -31,6 +31,10 @@ export default function PhoneVerification() {
     const role = searchParams.get("role");
     if (role === "parent" || role === "organizer") {
       sessionStorage.setItem("kiddaboo.pendingAccountType", role);
+      // Mark the onboarding flow as active so OnboardingOnly lets the
+      // user finish the multi-step signup even after setProfile() has
+      // populated first_name. Cleared at the terminal success page.
+      sessionStorage.setItem("kiddaboo.onboardingActive", "1");
     }
   }, [searchParams]);
 

--- a/frontend/src/pages/PhoneVerification.role-stash.test.jsx
+++ b/frontend/src/pages/PhoneVerification.role-stash.test.jsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import PhoneVerification from "./PhoneVerification";
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ signUp: vi.fn(), signIn: vi.fn() }),
+}));
+
+beforeEach(() => sessionStorage.clear());
+
+test("stashes role=organizer from query param on mount", () => {
+  render(
+    <MemoryRouter initialEntries={["/verify?role=organizer"]}>
+      <PhoneVerification />
+    </MemoryRouter>
+  );
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBe("organizer");
+});
+
+test("stashes role=parent from query param on mount", () => {
+  render(
+    <MemoryRouter initialEntries={["/verify?role=parent"]}>
+      <PhoneVerification />
+    </MemoryRouter>
+  );
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBe("parent");
+});
+
+test("does not stash an invalid role value", () => {
+  render(
+    <MemoryRouter initialEntries={["/verify?role=hacker"]}>
+      <PhoneVerification />
+    </MemoryRouter>
+  );
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBeNull();
+});
+
+test("does not overwrite an existing stash when role param is absent", () => {
+  sessionStorage.setItem("kiddaboo.pendingAccountType", "parent");
+  render(
+    <MemoryRouter initialEntries={["/verify"]}>
+      <PhoneVerification />
+    </MemoryRouter>
+  );
+  expect(sessionStorage.getItem("kiddaboo.pendingAccountType")).toBe("parent");
+});

--- a/frontend/src/pages/Welcome.jsx
+++ b/frontend/src/pages/Welcome.jsx
@@ -5,20 +5,20 @@ import { useAuth } from "../context/AuthContext";
 
 export default function Welcome() {
   const navigate = useNavigate();
-  const { user, profile, loading, isHost } = useAuth();
+  const { user, profile, loading } = useAuth();
 
   // If already logged in, check profile completeness and route by role
   useEffect(() => {
     if (!loading && user) {
       if (!profile?.first_name) {
         navigate("/profile");
-      } else if (isHost) {
+      } else if (profile.account_type === "organizer") {
         navigate("/host/dashboard");
       } else {
         navigate("/browse");
       }
     }
-  }, [user, profile, loading, isHost, navigate]);
+  }, [user, profile, loading, navigate]);
 
   if (loading) {
     return (
@@ -79,11 +79,8 @@ export default function Welcome() {
            the hierarchy is: one primary action → one secondary → one
            text link for returning users. */}
       <div className="w-full max-w-xs flex flex-col gap-4">
-        <Button fullWidth onClick={() => navigate("/verify")}>
+        <Button fullWidth onClick={() => navigate("/choose-role")}>
           Get Started
-        </Button>
-        <Button variant="secondary" fullWidth onClick={() => navigate("/host/create")}>
-          Host a Playgroup
         </Button>
         <button
           onClick={() => navigate("/verify?mode=signin")}

--- a/frontend/src/pages/admin/SubscriptionsTab.jsx
+++ b/frontend/src/pages/admin/SubscriptionsTab.jsx
@@ -118,7 +118,7 @@ export default function SubscriptionsTab({ subscriptions }) {
       {/* Revenue metric cards */}
       <div className="grid grid-cols-2 gap-3">
         <StatCard label="Active Joiner Subs" value={activeJoiners} icon="👤" />
-        <StatCard label="Active Host Subs" value={activeHosts} icon="🏠" />
+        <StatCard label="Active Organizer Subs" value={activeHosts} icon="🏠" />
         <StatCard label="MRR ($)" value={`$${mrrDollars}`} icon="💰" />
         <StatCard label="Total Subscribers" value={subscriptions.length} icon="📊" />
       </div>

--- a/frontend/src/pages/admin/SubscriptionsTab.jsx
+++ b/frontend/src/pages/admin/SubscriptionsTab.jsx
@@ -51,7 +51,7 @@ function isAnnualSub(sub) {
 }
 
 function getSubType(sub) {
-  return isHostSub(sub) ? "Host Premium" : "Joiner";
+  return isHostSub(sub) ? "Organizer Premium" : "Parent";
 }
 
 function getSubPlan(sub) {
@@ -151,7 +151,7 @@ export default function SubscriptionsTab({ subscriptions }) {
                   : "bg-white border border-cream-dark text-taupe hover:text-charcoal"
               }`}
             >
-              {f === "host" ? "Host Premium" : f === "joiner" ? "Joiner" : "All"}
+              {f === "host" ? "Organizer Premium" : f === "joiner" ? "Parent" : "All"}
             </button>
           ))}
         </div>

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -27,7 +27,7 @@ function timeAgo(dateStr) {
 }
 
 export default function HostDashboard() {
-  useDocumentTitle("Host Dashboard"); // #50
+  useDocumentTitle("Organizer Dashboard"); // #50
   const navigate = useNavigate();
   const { user, profile } = useAuth();
 

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -395,7 +395,7 @@ export default function HostDashboard() {
             onClick={() => navigate("/host/create")}
             className="bg-sage text-white font-medium rounded-2xl px-6 py-3 cursor-pointer border-none"
           >
-            Host a Playgroup
+            Organize a Playgroup
           </button>
         </div>
       </div>
@@ -556,7 +556,7 @@ export default function HostDashboard() {
                 </svg>
               </div>
               <div className="flex-1">
-                <p className="text-sm font-bold text-charcoal">Go Host Premium</p>
+                <p className="text-sm font-bold text-charcoal">Go Organizer Premium</p>
                 <p className="text-xs text-taupe leading-relaxed">
                   Get a Premium badge, priority placement, and see who's viewing your group.
                 </p>

--- a/frontend/src/pages/host/HostInsights.jsx
+++ b/frontend/src/pages/host/HostInsights.jsx
@@ -238,7 +238,7 @@ export default function HostInsights() {
             onClick={() => navigate("/host/create")}
             className="bg-sage text-white font-medium rounded-2xl px-6 py-3 cursor-pointer border-none"
           >
-            Host a Playgroup
+            Organize a Playgroup
           </button>
         </div>
       </div>

--- a/frontend/src/pages/host/HostInsights.jsx
+++ b/frontend/src/pages/host/HostInsights.jsx
@@ -22,7 +22,7 @@ function dayLabel(date) {
 }
 
 export default function HostInsights() {
-  useDocumentTitle("Host Insights"); // #50
+  useDocumentTitle("Organizer Insights"); // #50
   const navigate = useNavigate();
   const { user } = useAuth();
   const { isHostPremium } = useSubscription();

--- a/frontend/src/pages/host/HostPremium.jsx
+++ b/frontend/src/pages/host/HostPremium.jsx
@@ -55,7 +55,7 @@ const FEATURES = [
 ];
 
 export default function HostPremium() {
-  useDocumentTitle("Host Premium"); // #50
+  useDocumentTitle("Organizer Premium"); // #50
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user } = useAuth();
@@ -72,7 +72,7 @@ export default function HostPremium() {
   // Handle return from Stripe Checkout
   useEffect(() => {
     if (searchParams.get("success") === "true") {
-      setSuccessMessage("You're now a Host Premium member!");
+      setSuccessMessage("You're now an Organizer Premium member!");
       refresh();
     } else if (searchParams.get("cancelled") === "true") {
       setCancelMessage("Checkout cancelled — no charges were made.");
@@ -127,7 +127,7 @@ export default function HostPremium() {
             </svg>
           </button>
           <h1 className="font-bold text-base tracking-tight" style={{ fontFamily: "'ChunkFive', serif", color: '#5C6B52' }}>
-            Host Premium
+            Organizer Premium
           </h1>
         </div>
       </div>
@@ -165,7 +165,7 @@ export default function HostPremium() {
                 </svg>
               </div>
               <h2 className="font-heading font-bold text-charcoal text-xl mb-1">
-                You're Host Premium!
+                You're Organizer Premium!
               </h2>
               <p className="text-sm text-taupe mb-3">
                 {hostSubscription.plan === "host_annual" ? "Annual" : "Monthly"} plan
@@ -177,7 +177,7 @@ export default function HostPremium() {
 
             <div className="bg-white rounded-2xl border border-cream-dark p-5">
               <h3 className="font-heading font-semibold text-charcoal text-sm mb-3">
-                Your Host Premium benefits
+                Your Organizer Premium benefits
               </h3>
               <div className="space-y-4">
                 {FEATURES.map((f, i) => (

--- a/frontend/src/pages/host/HostSuccess.jsx
+++ b/frontend/src/pages/host/HostSuccess.jsx
@@ -21,6 +21,13 @@ export default function HostSuccess() {
   const [errorMsg, setErrorMsg] = useState("");
   const hasSaved = useRef(false);
 
+  // Terminal state for the organizer signup flow — clear the
+  // onboarding flag so OnboardingOnly correctly bounces future
+  // /profile visits to /my-profile.
+  useEffect(() => {
+    sessionStorage.removeItem("kiddaboo.onboardingActive");
+  }, []);
+
   // Save playgroup to Supabase when this page loads
   useEffect(() => {
     if (!user || hasSaved.current) return;

--- a/frontend/src/pages/onboarding/ChooseRole.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.jsx
@@ -1,0 +1,46 @@
+import { useNavigate } from "react-router-dom";
+
+/**
+ * First screen a new user sees. Picks their account_type before any
+ * signup happens. Per design D2, the choice is side-by-side with
+ * role-noun framing. The role is passed to /verify via query param;
+ * that page (Task 9) persists it after auth succeeds and before the
+ * profile row is updated with the real account_type.
+ */
+export default function ChooseRole() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center px-6 py-10">
+      <h1
+        className="text-3xl font-bold tracking-tight mb-2"
+        style={{ fontFamily: "'ChunkFive', serif", color: "#5C6B52" }}
+      >
+        Kiddaboo
+      </h1>
+      <p className="text-taupe text-center mb-10">Which best describes you?</p>
+
+      <div className="w-full max-w-md flex flex-col gap-4">
+        <button
+          onClick={() => navigate("/verify?role=parent")}
+          className="bg-white border-2 border-sage rounded-2xl p-6 text-left cursor-pointer hover:bg-sage-light/30 transition-colors"
+        >
+          <div className="text-xs text-sage-dark uppercase tracking-widest font-bold mb-2">Parent</div>
+          <div className="text-lg font-bold text-charcoal mb-1">I'm a Parent</div>
+          <div className="text-sm text-taupe">Looking for a playgroup for my child</div>
+        </button>
+
+        <button
+          onClick={() => navigate("/verify?role=organizer")}
+          className="bg-white border-2 border-terracotta rounded-2xl p-6 text-left cursor-pointer hover:bg-terracotta-light/30 transition-colors"
+        >
+          <div className="text-xs text-terracotta uppercase tracking-widest font-bold mb-2">Organizer</div>
+          <div className="text-lg font-bold text-charcoal mb-1">I'm an Organizer</div>
+          <div className="text-sm text-taupe">Starting or running a playgroup</div>
+        </button>
+      </div>
+
+      <p className="text-xs text-taupe/60 mt-6">You can add the other role later.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/onboarding/ChooseRole.test.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ChooseRole from "./ChooseRole";
+import { vi } from "vitest";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => ({
+  ...(await vi.importActual("react-router-dom")),
+  useNavigate: () => navigate,
+}));
+
+beforeEach(() => navigate.mockClear());
+
+test("clicking Parent card routes to /verify?role=parent", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /I'm a Parent/i }));
+  expect(navigate).toHaveBeenCalledWith("/verify?role=parent");
+});
+
+test("clicking Organizer card routes to /verify?role=organizer", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  fireEvent.click(screen.getByRole("button", { name: /I'm an Organizer/i }));
+  expect(navigate).toHaveBeenCalledWith("/verify?role=organizer");
+});
+
+test("renders footer note about adding the other role later", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  expect(screen.getByText(/add the other role later/i)).toBeInTheDocument();
+});

--- a/frontend/src/test/regression.test.jsx
+++ b/frontend/src/test/regression.test.jsx
@@ -184,7 +184,7 @@ describe("Public Pages", () => {
     it("renders all CTA buttons", () => {
       renderWithRouter(<Welcome />);
       expect(screen.getByText("Find Your Playgroup")).toBeInTheDocument();
-      expect(screen.getByText("Host a Playgroup")).toBeInTheDocument();
+      expect(screen.getByText("Organize a Playgroup")).toBeInTheDocument();
     });
 
     it("renders sign in and create account links", () => {

--- a/supabase/migrations/20260416000001_1_handle_new_user_account_type.sql
+++ b/supabase/migrations/20260416000001_1_handle_new_user_account_type.sql
@@ -1,0 +1,24 @@
+-- 20260416000001_1_handle_new_user_account_type.sql
+-- HOTFIX: the previous migration dropped the default on
+-- profiles.account_type, but the handle_new_user auth trigger does a
+-- bare INSERT without supplying a value. Every new signup was
+-- failing with a NOT NULL violation.
+--
+-- Fix: have the trigger write a placeholder 'parent' value on
+-- creation. The app's ChooseRole flow calls updateProfile() to set
+-- the real account_type immediately after signup (Task 9). Users
+-- who never complete onboarding remain 'parent', which is a safe
+-- default — they never see the Organizer UI because the layout
+-- wrappers in Task 10 only activate post-ChooseRole anyway.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    INSERT INTO public.profiles (id, account_type)
+    VALUES (NEW.id, 'parent');
+    RETURN NEW;
+END;
+$function$;

--- a/supabase/migrations/20260416000001_add_account_type.sql
+++ b/supabase/migrations/20260416000001_add_account_type.sql
@@ -1,0 +1,29 @@
+-- 20260416000001_add_account_type.sql
+-- Adds profiles.account_type so we can distinguish Parent vs Organizer
+-- users without the expensive memberships.role='creator' lookup every
+-- AuthContext fetch does today.
+
+ALTER TABLE profiles
+  ADD COLUMN account_type TEXT
+  CHECK (account_type IN ('parent', 'organizer'))
+  NOT NULL DEFAULT 'parent';
+
+-- Backfill: anyone who has ever been a group creator is an organizer.
+-- Everyone else stays 'parent' (the default).
+UPDATE profiles p
+SET account_type = 'organizer'
+WHERE EXISTS (
+  SELECT 1
+  FROM memberships m
+  WHERE m.user_id = p.id
+    AND m.role = 'creator'
+);
+
+-- Drop the default so new signups MUST pick a role explicitly via the
+-- ChooseRole path picker. Any insert that omits account_type will now
+-- error, which is what we want.
+ALTER TABLE profiles ALTER COLUMN account_type DROP DEFAULT;
+
+-- Index — we'll filter by account_type in admin views and usage stats.
+CREATE INDEX IF NOT EXISTS profiles_account_type_idx
+  ON profiles (account_type);


### PR DESCRIPTION
## Summary

Milestone 1 of the role identity & trust work. Ships perceptual separation between the two audiences (Parent / Organizer), a signup path picker, role-aware layouts and bottom nav, route guards, and the user-facing "Host" → "Organizer" rename.

Design: `docs/superpowers/specs/2026-04-15-role-identity-and-trust-design.md`
Plan: `docs/superpowers/plans/2026-04-15-role-identity-and-trust.md`

**What changed:**
- New `profiles.account_type` column (`parent` | `organizer`), backfilled for existing creators
- `handle_new_user` trigger updated to supply `'parent'` placeholder so new signups don't NOT-NULL-violate
- `AuthContext` exposes `accountType`; new `useAccountType` hook + `RequireRole` route guard
- New `ParentLayout` (sage) and `OrganizerLayout` (terracotta) wrap role-specific routes
- `TabBar` renders Parent or Organizer tab set based on role
- New `/choose-role` signup landing with two side-by-side cards; role persists through phone verification via `sessionStorage` and writes to `profiles.account_type` in CreateProfile
- `/browse` and `/my-groups` now require `role="parent"`; `/host/dashboard` and `/host/insights` require `role="organizer"`; wrong-role access silently redirects to the correct home
- User-facing "Host" → "Organizer" rename across 9 files (18 strings total); DB identifiers, route paths, component names, and `isHost` variable untouched
- Welcome page: "Get Started" now routes to `/choose-role`; redundant "Host a Playgroup" secondary button removed

**Out of scope (future milestones):**
- M2: phone OTP verification (Twilio-backed) — plan tasks 13-19
- M3: profile panel trust redesign — plan tasks 20-24

## Test plan

- [ ] `/` → Get Started → `/choose-role` shows both role cards
- [ ] Sign up as Parent → lands on `/browse` with sage "Parent" header label, Parent bottom nav (Browse / My Groups / Messages / Profile)
- [ ] Sign up as Organizer (separate browser) → lands on `/host/dashboard` with terracotta "Organizer" header, Organizer nav (My Group / Members / Messages / Profile)
- [ ] Parent manually navigates to `/host/dashboard` → silently redirected to `/browse`
- [ ] Organizer manually navigates to `/browse` → silently redirected to `/host/dashboard`
- [ ] `/my-profile` renders for both roles; Organizer sees "Upgrade to Organizer Premium"
- [ ] Admin `/admin` Subscriptions tab shows filter labeled "Organizer Premium" / "Parent" and stat card "Active Organizer Subs"
- [ ] Browse greeting for organizers reads "Hi, <name> (Organizer)"
- [ ] Vitest suite green except the 5 pre-existing regression-test failures in `src/test/regression.test.jsx` (Welcome CTAs / Browse filters — unrelated to this branch; tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)