### PR TITLE
Graceful UX when verifying a phone already in use

### DIFF
--- a/frontend/src/hooks/usePhoneVerification.js
+++ b/frontend/src/hooks/usePhoneVerification.js
@@ -29,8 +29,8 @@ export function usePhoneVerification() {
     const { data, error } = await supabase.functions.invoke("verify-otp", { body: { phone, code } });
     if (error || !data?.ok) {
       setStatus("error");
-      setError(error?.message || "verify_failed");
-      return { error: error ?? new Error("verify_failed") };
+      setError(data?.error || error?.message || "verify_failed");
+      return { error: error ?? new Error(data?.error || "verify_failed") };
     }
     setStatus("verified");
     return { data, error: null };

--- a/frontend/src/hooks/usePhoneVerification.test.jsx
+++ b/frontend/src/hooks/usePhoneVerification.test.jsx
@@ -41,3 +41,13 @@ test("verifyCode surfaces mismatch error", async () => {
   expect(result.current.error).toBe("code_mismatch");
   expect(result.current.status).toBe("error");
 });
+
+test("verifyCode surfaces phone_in_use from ok:false body", async () => {
+  supabase.functions.invoke.mockResolvedValue({ data: { ok: false, error: "phone_in_use" }, error: null });
+  const { result } = renderHook(() => usePhoneVerification());
+  await act(async () => {
+    await result.current.verifyCode("+15551234567", "123456");
+  });
+  expect(result.current.error).toBe("phone_in_use");
+  expect(result.current.status).toBe("error");
+});

--- a/frontend/src/pages/onboarding/PhoneVerify.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
 import { usePhoneVerification } from "../../hooks/usePhoneVerification";
 
@@ -92,7 +92,16 @@ export default function PhoneVerify() {
               className="border border-cream-dark rounded-xl px-4 py-3 text-center text-2xl tracking-widest"
               required
             />
-            {error && <p className="text-xs text-terracotta">{error === "code_mismatch" ? "Code doesn't match. Try again." : "Something went wrong. Try again."}</p>}
+            {error === "phone_in_use" ? (
+              <p className="text-xs text-terracotta">
+                This phone is already linked to another account.{" "}
+                <Link to="/login" className="underline">Sign in instead?</Link>
+              </p>
+            ) : error ? (
+              <p className="text-xs text-terracotta">
+                {error === "code_mismatch" ? "Code doesn't match. Try again." : "Something went wrong. Try again."}
+              </p>
+            ) : null}
             <Button type="submit" disabled={status === "verifying"}>
               {status === "verifying" ? "Verifying…" : "Verify"}
             </Button>

--- a/frontend/src/pages/onboarding/PhoneVerify.test.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.test.jsx
@@ -6,13 +6,25 @@ import { vi } from "vitest";
 const sendCode = vi.fn().mockResolvedValue({ error: null });
 const verifyCode = vi.fn().mockResolvedValue({ data: { ok: true }, error: null });
 let status = "idle";
+let error = null;
 vi.mock("../../hooks/usePhoneVerification", () => ({
-  usePhoneVerification: () => ({ status, error: null, sendCode, verifyCode, reset: vi.fn() }),
+  usePhoneVerification: () => ({ status, error, sendCode, verifyCode, reset: vi.fn() }),
 }));
 
 test("full flow: enter phone, send code, enter code, verified", async () => {
+  status = "idle";
+  error = null;
   render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
   fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: "+15551234567" } });
   fireEvent.click(screen.getByRole("button", { name: /send code/i }));
   await waitFor(() => expect(sendCode).toHaveBeenCalledWith("+15551234567"));
+});
+
+test("phone_in_use error shows sign-in CTA", () => {
+  status = "error";
+  error = "phone_in_use";
+  render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
+  expect(screen.getByText(/already linked to another account/i)).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: /sign in instead/i });
+  expect(link).toHaveAttribute("href", "/login");
 });

--- a/supabase/functions/verify-otp/index.ts
+++ b/supabase/functions/verify-otp/index.ts
@@ -98,7 +98,18 @@ serve(async (req) => {
     .from("profiles")
     .update({ phone_number: phone, phone_verified_at: now })
     .eq("id", userId);
-  if (profErr) return json({ error: "db_error", detail: profErr.message }, 500);
+  if (profErr) {
+    // Unique violation on profiles.phone_number means the phone is
+    // already linked to a different account. Surface a dedicated
+    // error so the client can offer sign-in instead of the generic
+    // "something went wrong". supabase-js swallows non-2xx bodies, so
+    // we return 200 with ok:false to keep the code reachable on the
+    // client side.
+    if ((profErr as { code?: string }).code === "23505") {
+      return json({ ok: false, error: "phone_in_use" });
+    }
+    return json({ error: "db_error", detail: profErr.message }, 500);
+  }
 
   return json({ ok: true, verified_at: now });
 });


### PR DESCRIPTION
## Summary
- `verify-otp` catches pgcode `23505` (unique violation on `profiles.phone_number`) and returns `{ ok: false, error: "phone_in_use" }` instead of a generic 500.
- `PhoneVerify.jsx` branches on `phone_in_use` to show "This phone is already linked to another account. **Sign in instead?**" with a link to `/login`.
- Hook now propagates `data?.error` so response-body error codes survive supabase-js's non-2xx stripping (hence 200 with `ok:false` rather than 409).

## Context
Follow-up to [#66](https://github.com/Sureshk972/kiddaboo/pull/66) (M2 phone OTP). Previously, a second user hitting the same phone got "Something went wrong. Try again." with no way out. Surfaced during real-SMS smoke test on 2026-04-15.

## Test plan
- [x] Unit: `usePhoneVerification.verifyCode` surfaces `phone_in_use` from ok:false body
- [x] Unit: `PhoneVerify` renders sign-in CTA linking `/login` when `error === "phone_in_use"`
- [ ] Manual smoke on Netlify deploy preview: sign up second account, try to verify a phone already linked to another account, confirm friendly copy + sign-in link shows (requires edge function deploy to prod Supabase — see note below)

## Note on rollout
Edge function change is **not live until `supabase functions deploy verify-otp`** is run against project `pdgtryghvibhmmroqvdk`. Until then the client will still fall through to the generic "Something went wrong" string for duplicate phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)