### PR TITLE
Keep user on phone form when Send fails

### DIFF
--- a/frontend/src/hooks/usePhoneVerification.js
+++ b/frontend/src/hooks/usePhoneVerification.js
@@ -4,7 +4,11 @@ import { supabase } from "../lib/supabase";
 /**
  * Drives the OTP UI. Status machine:
  *   idle → sending → code_sent → verifying → verified
- *                                        ↘ error
+ *              ↘ send_error              ↘ verify_error
+ *
+ * send_error and verify_error are split so the UI can keep the user
+ * on the correct form: send failures must NOT drop them onto the
+ * code-entry screen, because no code was ever sent.
  */
 export function usePhoneVerification() {
   const [status, setStatus] = useState("idle");
@@ -13,11 +17,11 @@ export function usePhoneVerification() {
   async function sendCode(phone) {
     setStatus("sending");
     setError(null);
-    const { error } = await supabase.functions.invoke("send-otp", { body: { phone } });
-    if (error) {
-      setStatus("error");
-      setError(error.message || "send_failed");
-      return { error };
+    const { data, error } = await supabase.functions.invoke("send-otp", { body: { phone } });
+    if (error || !data?.ok) {
+      setStatus("send_error");
+      setError(data?.error || error?.message || "send_failed");
+      return { error: error ?? new Error(data?.error || "send_failed") };
     }
     setStatus("code_sent");
     return { error: null };
@@ -28,7 +32,7 @@ export function usePhoneVerification() {
     setError(null);
     const { data, error } = await supabase.functions.invoke("verify-otp", { body: { phone, code } });
     if (error || !data?.ok) {
-      setStatus("error");
+      setStatus("verify_error");
       setError(data?.error || error?.message || "verify_failed");
       return { error: error ?? new Error(data?.error || "verify_failed") };
     }

--- a/frontend/src/hooks/usePhoneVerification.test.jsx
+++ b/frontend/src/hooks/usePhoneVerification.test.jsx
@@ -22,6 +22,16 @@ test("sendCode invokes the send-otp function with the phone", async () => {
   await waitFor(() => expect(result.current.status).toBe("code_sent"));
 });
 
+test("sendCode surfaces sms_failed from ok:false body and transitions to send_error", async () => {
+  supabase.functions.invoke.mockResolvedValue({ data: { ok: false, error: "sms_failed" }, error: null });
+  const { result } = renderHook(() => usePhoneVerification());
+  await act(async () => {
+    await result.current.sendCode("+15551234567");
+  });
+  expect(result.current.error).toBe("sms_failed");
+  expect(result.current.status).toBe("send_error");
+});
+
 test("verifyCode invokes verify-otp and transitions to verified on ok", async () => {
   supabase.functions.invoke.mockResolvedValue({ data: { ok: true, verified_at: "now" }, error: null });
   const { result } = renderHook(() => usePhoneVerification());
@@ -32,14 +42,14 @@ test("verifyCode invokes verify-otp and transitions to verified on ok", async ()
   await waitFor(() => expect(result.current.status).toBe("verified"));
 });
 
-test("verifyCode surfaces mismatch error", async () => {
+test("verifyCode surfaces mismatch error as verify_error", async () => {
   supabase.functions.invoke.mockResolvedValue({ data: null, error: { message: "code_mismatch" } });
   const { result } = renderHook(() => usePhoneVerification());
   await act(async () => {
     await result.current.verifyCode("+15551234567", "000000");
   });
   expect(result.current.error).toBe("code_mismatch");
-  expect(result.current.status).toBe("error");
+  expect(result.current.status).toBe("verify_error");
 });
 
 test("verifyCode surfaces phone_in_use from ok:false body", async () => {
@@ -49,5 +59,5 @@ test("verifyCode surfaces phone_in_use from ok:false body", async () => {
     await result.current.verifyCode("+15551234567", "123456");
   });
   expect(result.current.error).toBe("phone_in_use");
-  expect(result.current.status).toBe("error");
+  expect(result.current.status).toBe("verify_error");
 });

--- a/frontend/src/pages/onboarding/PhoneVerify.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.jsx
@@ -3,6 +3,19 @@ import { Link, useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
 import { usePhoneVerification } from "../../hooks/usePhoneVerification";
 
+// User-friendly copy per error code. Keys match codes returned by
+// send-otp and verify-otp edge functions.
+const SEND_ERROR_COPY = {
+  invalid_phone: "That doesn't look like a valid phone number. Check it and try again.",
+  sms_failed: "We couldn't text that number. Check that it's correct and can receive SMS, or try another number.",
+  rate_limited: "Too many code requests for that number. Wait a few minutes and try again.",
+};
+const VERIFY_ERROR_COPY = {
+  code_mismatch: "Code doesn't match. Try again.",
+  no_active_challenge: "That code expired. Tap Resend to get a new one.",
+  phone_in_use: null, // handled inline as JSX (link to /login)
+};
+
 /**
  * OTP step. Two stages:
  *   1. Ask for E.164 phone → "Send code"
@@ -51,7 +64,10 @@ export default function PhoneVerify() {
     }
   }
 
-  const showCodeStep = status === "code_sent" || status === "verifying" || status === "error";
+  // Code-entry form only appears once a code has actually been sent.
+  // send_error keeps us on the phone form so the user can fix the
+  // number; verify_error keeps us on the code form.
+  const showCodeStep = status === "code_sent" || status === "verifying" || status === "verify_error";
 
   return (
     <div className="min-h-screen bg-cream px-6 py-10 flex flex-col">
@@ -73,6 +89,11 @@ export default function PhoneVerify() {
               className="border border-cream-dark rounded-xl px-4 py-3"
               required
             />
+            {status === "send_error" && (
+              <p className="text-xs text-terracotta">
+                {SEND_ERROR_COPY[error] || "Something went wrong. Try again."}
+              </p>
+            )}
             <Button type="submit" disabled={status === "sending"}>
               {status === "sending" ? "Sending…" : "Send code"}
             </Button>
@@ -99,7 +120,7 @@ export default function PhoneVerify() {
               </p>
             ) : error ? (
               <p className="text-xs text-terracotta">
-                {error === "code_mismatch" ? "Code doesn't match. Try again." : "Something went wrong. Try again."}
+                {VERIFY_ERROR_COPY[error] || "Something went wrong. Try again."}
               </p>
             ) : null}
             <Button type="submit" disabled={status === "verifying"}>

--- a/frontend/src/pages/onboarding/PhoneVerify.test.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.test.jsx
@@ -20,8 +20,24 @@ test("full flow: enter phone, send code, enter code, verified", async () => {
   await waitFor(() => expect(sendCode).toHaveBeenCalledWith("+15551234567"));
 });
 
-test("phone_in_use error shows sign-in CTA", () => {
-  status = "error";
+test("send_error keeps the user on the phone form with helpful copy", () => {
+  status = "send_error";
+  error = "sms_failed";
+  render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
+  expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
+  expect(screen.queryByLabelText(/6-digit code/i)).not.toBeInTheDocument();
+  expect(screen.getByText(/couldn't text that number/i)).toBeInTheDocument();
+});
+
+test("send_error shows rate-limit copy when relevant", () => {
+  status = "send_error";
+  error = "rate_limited";
+  render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
+  expect(screen.getByText(/too many code requests/i)).toBeInTheDocument();
+});
+
+test("phone_in_use error shows sign-in CTA on code form", () => {
+  status = "verify_error";
   error = "phone_in_use";
   render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
   expect(screen.getByText(/already linked to another account/i)).toBeInTheDocument();

--- a/supabase/functions/send-otp/index.ts
+++ b/supabase/functions/send-otp/index.ts
@@ -74,7 +74,7 @@ serve(async (req) => {
     return json({ error: "bad_json" }, 400);
   }
   if (!/^\+[1-9]\d{6,14}$/.test(phone || "")) {
-    return json({ error: "invalid_phone" }, 400);
+    return json({ ok: false, error: "invalid_phone" });
   }
 
   // Twilio Verify handles code generation, expiry, delivery, and the
@@ -82,14 +82,17 @@ serve(async (req) => {
   const result = await twilioStartVerification(phone);
   if (!result.ok) {
     console.error("twilio verify start failed:", result.status, result.body);
-    // Twilio's 60212 (max send attempts reached) is our rate-limit case;
-    // surface that to the UI so the copy can be accurate. Everything
-    // else is a generic send failure.
+    // Surface user-actionable errors as ok:false bodies (supabase-js
+    // swallows non-2xx bodies, so the 200-with-ok:false pattern is
+    // how we get the error code to the UI). Twilio's 60212 is the
+    // rate-limit case; 60200 / 60203 / 60410 are "this number can't
+    // receive SMS", which from a trial account also covers the
+    // "unverified caller ID" case.
     const twilioCode = (result.body as { code?: number })?.code;
     if (twilioCode === 60212) {
-      return json({ error: "rate_limited" }, 429);
+      return json({ ok: false, error: "rate_limited" });
     }
-    return json({ error: "sms_failed", detail: result.body }, 502);
+    return json({ ok: false, error: "sms_failed", detail: result.body });
   }
 
   return json({ ok: true });


### PR DESCRIPTION
## Summary
Send failures used to drop the user onto the 6-digit code entry screen with a generic "Something went wrong" — no way to correct the phone number. This splits the error state into `send_error` vs `verify_error` so the UI stays on the correct form, and adds specific copy per error code.

## Changes
- `send-otp` edge function: return 200 with `{ ok: false, error: "<code>" }` for `invalid_phone` / `sms_failed` / `rate_limited` (supabase-js swallows non-2xx bodies, so the error code has to live in the 200 response).
- `usePhoneVerification`: split `error` status into `send_error` and `verify_error`.
- `PhoneVerify.jsx`: gate code-entry form on `code_sent || verifying || verify_error` only. Add per-code copy: "We couldn't text that number..." / "Too many code requests..." / "That code expired — tap Resend".
- Edge function deployed to prod Supabase (`pdgtryghvibhmmroqvdk`).

## Test plan
- [x] 9 unit tests pass (hook + page)
- [ ] On deploy preview: enter an unverified Twilio trial number → see the friendly "couldn't text" copy on the phone form, NOT the code form

🤖 Generated with [Claude Code](https://claude.com/claude-code)