### PR TITLE
Show initials fallback when no profile photo

### DIFF
--- a/frontend/src/components/profile/ProfilePanel.jsx
+++ b/frontend/src/components/profile/ProfilePanel.jsx
@@ -39,7 +39,15 @@ export default function ProfilePanel({ profile, onMessage }) {
     <div className="bg-cream rounded-t-2xl p-5 max-w-md mx-auto">
       <div className="flex flex-col items-center text-center mb-3">
         <div className="relative inline-block">
-          <div className="w-20 h-20 rounded-full bg-sage-light border-[3px] border-white shadow" />
+          <div className="w-20 h-20 rounded-full bg-sage-light border-[3px] border-white shadow flex items-center justify-center overflow-hidden">
+            {profile.photo_url ? (
+              <img src={profile.photo_url} alt={`${fullName || "user"}'s photo`} className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-2xl font-heading font-bold text-sage-dark">
+                {(profile.first_name?.[0] || "") + (profile.last_name?.[0] || "")}
+              </span>
+            )}
+          </div>
           <div className="absolute bottom-0 right-0">
             <VerifiedBadge verified={verified} />
           </div>

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -558,10 +558,18 @@ export default function PlaygroupDetail() {
                     className="bg-white rounded-xl border border-cream-dark p-3 flex gap-3 items-center text-left cursor-pointer"
                   >
                     <div
-                      className={`w-10 h-10 rounded-full bg-sage-light flex-shrink-0 ${
+                      className={`w-10 h-10 rounded-full bg-sage-light flex-shrink-0 flex items-center justify-center overflow-hidden ${
                         isOrganizer ? "border-[3px] border-terracotta" : ""
                       }`}
-                    />
+                    >
+                      {m.photo_url ? (
+                        <img src={m.photo_url} alt={`${m.first_name || "member"}'s photo`} className="w-full h-full object-cover" />
+                      ) : (
+                        <span className="text-sm font-heading font-bold text-sage-dark">
+                          {m.initials}
+                        </span>
+                      )}
+                    </div>
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
                         <div className="font-bold text-sm text-charcoal">


### PR DESCRIPTION
## Summary
The blank sage circle in the unified member list (and in the ProfilePanel sheet) read as a broken image. Fall back to first+last initials centered in the circle when there's no `photo_url`, matching the pattern on MyProfile.

## Files
- `frontend/src/pages/PlaygroupDetail.jsx` — member row avatar
- `frontend/src/components/profile/ProfilePanel.jsx` — big sheet avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)