### PR TITLE
Add sign-in link to ChooseRole for returning users

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "kiddaboo",
+      "runtimeExecutable": "/usr/local/bin/npx",
+      "runtimeArgs": ["vite", "--port", "5173", "--host"],
+      "port": 5173,
+      "cwd": "/Users/sureshkumar/Kiddaboo/frontend"
+    }
+  ]
+}

--- a/frontend/src/pages/onboarding/ChooseRole.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 /**
  * First screen a new user sees. Picks their account_type before any
@@ -41,6 +41,11 @@ export default function ChooseRole() {
       </div>
 
       <p className="text-xs text-taupe/60 mt-6">You can add the other role later.</p>
+
+      <p className="text-sm text-taupe mt-8">
+        Already have an account?{" "}
+        <Link to="/login" className="underline underline-offset-4 text-charcoal">Sign in</Link>
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/onboarding/ChooseRole.test.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.test.jsx
@@ -27,3 +27,9 @@ test("renders footer note about adding the other role later", () => {
   render(<MemoryRouter><ChooseRole /></MemoryRouter>);
   expect(screen.getByText(/add the other role later/i)).toBeInTheDocument();
 });
+
+test("offers a sign-in link for returning users", () => {
+  render(<MemoryRouter><ChooseRole /></MemoryRouter>);
+  const link = screen.getByRole("link", { name: /sign in/i });
+  expect(link).toHaveAttribute("href", "/login");
+});


### PR DESCRIPTION
## Summary
- Returning users clicking "Get Started" now see an "Already have an account? Sign in" link under the role cards
- Matches the pattern already used on the home page (Welcome.jsx)
- Routes to `/login`

## Test plan
- [x] ChooseRole.test.jsx covers the new link (4 tests pass)
- [ ] Netlify deploy preview: confirm link is visible and routes to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)