### PR TITLE
Hide Report menu from hosts on their own playgroup

### DIFF
--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -276,7 +276,22 @@ export default function PlaygroupDetail() {
         <h2 className="font-heading font-bold text-charcoal text-sm truncate flex-1">
           {group.name}
         </h2>
-        {user && joinStatus !== "creator" && (
+        {user && group.host?.userId === user.id && previewMode ? (
+          // Host previewing their own group: show a muted, non-clickable
+          // version so they can see what parents see without risking an
+          // accidental Report on themselves.
+          <div
+            className="w-8 h-8 rounded-full bg-cream border border-cream-dark flex items-center justify-center flex-shrink-0 opacity-50"
+            title="Parents see this — they can Report or Block from here"
+            aria-label="Parents can report or block from here"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="5" r="1.5" fill="#6B5E54"/>
+              <circle cx="12" cy="12" r="1.5" fill="#6B5E54"/>
+              <circle cx="12" cy="19" r="1.5" fill="#6B5E54"/>
+            </svg>
+          </div>
+        ) : user && group.host?.userId !== user.id && joinStatus !== "creator" && (
           <button
             onClick={() =>
               setReportTarget({


### PR DESCRIPTION
## Summary
- Hosts no longer see the 3-dot Report/Block menu on their own playgroup in live mode
- In preview mode, a muted non-clickable version appears with a tooltip: "Parents see this — they can Report or Block from here"
- Uses `creator_id` match as the authoritative host check (was previously relying on membership role, which preview mode intentionally ignores)

## Test plan
- [ ] As host, visit your own playgroup in live mode → no 3-dot menu
- [ ] As host, enter preview mode → muted 3-dot appears with tooltip, not clickable
- [ ] As parent/visitor → full Report menu still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)