### PR TITLE
Fix Sign in links routing to non-existent /login

### DIFF
--- a/frontend/src/pages/onboarding/ChooseRole.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.jsx
@@ -44,7 +44,7 @@ export default function ChooseRole() {
 
       <p className="text-sm text-taupe mt-8">
         Already have an account?{" "}
-        <Link to="/login" className="underline underline-offset-4 text-charcoal">Sign in</Link>
+        <Link to="/verify?mode=signin" className="underline underline-offset-4 text-charcoal">Sign in</Link>
       </p>
     </div>
   );

--- a/frontend/src/pages/onboarding/ChooseRole.test.jsx
+++ b/frontend/src/pages/onboarding/ChooseRole.test.jsx
@@ -31,5 +31,5 @@ test("renders footer note about adding the other role later", () => {
 test("offers a sign-in link for returning users", () => {
   render(<MemoryRouter><ChooseRole /></MemoryRouter>);
   const link = screen.getByRole("link", { name: /sign in/i });
-  expect(link).toHaveAttribute("href", "/login");
+  expect(link).toHaveAttribute("href", "/verify?mode=signin");
 });

--- a/frontend/src/pages/onboarding/PhoneVerify.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.jsx
@@ -116,7 +116,7 @@ export default function PhoneVerify() {
             {error === "phone_in_use" ? (
               <p className="text-xs text-terracotta">
                 This phone is already linked to another account.{" "}
-                <Link to="/login" className="underline">Sign in instead?</Link>
+                <Link to="/verify?mode=signin" className="underline">Sign in instead?</Link>
               </p>
             ) : error ? (
               <p className="text-xs text-terracotta">

--- a/frontend/src/pages/onboarding/PhoneVerify.test.jsx
+++ b/frontend/src/pages/onboarding/PhoneVerify.test.jsx
@@ -42,5 +42,5 @@ test("phone_in_use error shows sign-in CTA on code form", () => {
   render(<MemoryRouter><PhoneVerify /></MemoryRouter>);
   expect(screen.getByText(/already linked to another account/i)).toBeInTheDocument();
   const link = screen.getByRole("link", { name: /sign in instead/i });
-  expect(link).toHaveAttribute("href", "/login");
+  expect(link).toHaveAttribute("href", "/verify?mode=signin");
 });


### PR DESCRIPTION
Fixes #75

## Summary
- Points ChooseRole and PhoneVerify Sign in links to `/verify?mode=signin` (matching Welcome.jsx)
- Updates tests

## Test plan
- [x] Onboarding tests pass (8/8)
- [x] Local preview: Sign in link on /choose-role now points to /verify?mode=signin

🤖 Generated with [Claude Code](https://claude.com/claude-code)