### PR TITLE
Redesign session cancellation workflow

### DIFF
--- a/frontend/src/components/playgroup/CancelSessionSheet.jsx
+++ b/frontend/src/components/playgroup/CancelSessionSheet.jsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from "react";
+import Button from "../ui/Button";
+
+// Sheet that replaces the native confirm() for session cancellation.
+// Shows how many families will be affected, lets the host add an
+// optional reason, and forwards both to the parent's onConfirm so the
+// hook can post a system message in the group chat.
+export default function CancelSessionSheet({
+  isOpen,
+  onClose,
+  onConfirm,
+  rsvpCount = 0,
+  sessionDateLabel,
+}) {
+  const [reason, setReason] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setReason("");
+      setError("");
+      setSaving(false);
+      return;
+    }
+    function onKeyDown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = async () => {
+    setSaving(true);
+    setError("");
+    const result = await onConfirm?.(reason);
+    if (result?.error) {
+      setError("Couldn't cancel the session. Try again.");
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+    onClose?.();
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-charcoal/40 z-40 transition-opacity"
+        onClick={onClose}
+      />
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-cream rounded-t-3xl max-h-[85vh] overflow-y-auto">
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="w-10 h-1 bg-cream-dark rounded-full" />
+        </div>
+
+        <div className="px-6 pb-8">
+          <h3 className="text-xl font-heading font-bold text-charcoal mb-1">
+            Cancel this session?
+          </h3>
+          <p className="text-sm text-taupe mb-4">
+            {sessionDateLabel
+              ? `The ${sessionDateLabel} session will be removed from the schedule.`
+              : "This session will be removed from the schedule."}
+          </p>
+
+          {rsvpCount > 0 ? (
+            <div className="bg-terracotta-light/40 border border-terracotta/30 rounded-xl px-4 py-3 mb-5">
+              <p className="text-sm text-charcoal font-medium">
+                {rsvpCount} {rsvpCount === 1 ? "family is" : "families are"} RSVP'd
+              </p>
+              <p className="text-xs text-taupe-dark mt-0.5">
+                They'll get a message in the group chat letting them know.
+              </p>
+            </div>
+          ) : (
+            <div className="bg-sage-light/40 border border-sage/30 rounded-xl px-4 py-3 mb-5">
+              <p className="text-sm text-charcoal">
+                No families have RSVP'd yet.
+              </p>
+            </div>
+          )}
+
+          <div className="mb-5">
+            <label className="text-sm font-medium text-taupe block mb-1.5">
+              Reason (optional)
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Weather, illness, scheduling — anything you want parents to know."
+              maxLength={280}
+              rows={3}
+              className="
+                w-full bg-white border border-cream-dark rounded-xl px-4 py-3
+                text-charcoal font-body text-sm outline-none transition-all duration-150
+                resize-none placeholder:text-taupe/40
+                focus:ring-2 focus:ring-sage-light focus:border-sage
+              "
+            />
+            <span className="text-[11px] text-taupe/50 block text-right mt-1">
+              {reason.length}/280
+            </span>
+          </div>
+
+          {error && (
+            <p className="text-xs text-terracotta mb-3">{error}</p>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={handleConfirm}
+              disabled={saving}
+              className="w-full bg-terracotta text-white font-bold text-sm rounded-2xl px-4 py-3 cursor-pointer border-none hover:bg-terracotta/90 transition-colors disabled:opacity-60"
+            >
+              {saving ? "Cancelling…" : "Cancel session"}
+            </button>
+            <Button variant="secondary" onClick={onClose} disabled={saving}>
+              Keep session
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/hooks/useSessions.js
+++ b/frontend/src/hooks/useSessions.js
@@ -12,6 +12,7 @@ export default function useSessions(playgroupId) {
       .from("sessions")
       .select("*")
       .eq("playgroup_id", playgroupId)
+      .is("cancelled_at", null)
       .gte("scheduled_at", new Date().toISOString())
       .order("scheduled_at", { ascending: true });
 
@@ -73,19 +74,55 @@ export default function useSessions(playgroupId) {
     [playgroupId]
   );
 
-  // Delete a session
-  const deleteSession = useCallback(async (sessionId) => {
-    const { error } = await supabase
-      .from("sessions")
-      .delete()
-      .eq("id", sessionId);
-
-    if (!error) {
-      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
-    }
-
-    return { error };
+  // Count RSVPs on a session so the host can see who will be affected
+  // before confirming a cancellation. "going" matches useRsvps — we
+  // don't surface "maybe" / "can't" in the count because cancellation
+  // only disrupts people who committed.
+  const countRsvps = useCallback(async (sessionId) => {
+    const { count } = await supabase
+      .from("rsvps")
+      .select("id", { count: "exact", head: true })
+      .eq("session_id", sessionId)
+      .eq("status", "going");
+    return count || 0;
   }, []);
+
+  // Soft-cancel a session. Keeps the row + RSVPs (audit trail, future
+  // review surfaces), and posts a system message in the group chat so
+  // RSVP'd parents see the cancellation and any reason the host typed.
+  // The chat message uses the host as sender — we don't have a system
+  // identity and messages.sender_id is non-null, so attributing it to
+  // the host is both accurate and the minimal schema change.
+  const cancelSession = useCallback(
+    async (sessionId, { reason, hostUserId, sessionDateLabel } = {}) => {
+      const { error } = await supabase
+        .from("sessions")
+        .update({
+          cancelled_at: new Date().toISOString(),
+          cancel_reason: reason?.trim() || null,
+        })
+        .eq("id", sessionId);
+
+      if (error) return { error };
+
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+
+      if (playgroupId && hostUserId) {
+        const trimmed = reason?.trim();
+        const body = trimmed
+          ? `🚫 The ${sessionDateLabel || "upcoming"} session was cancelled. ${trimmed}`
+          : `🚫 The ${sessionDateLabel || "upcoming"} session was cancelled.`;
+        await supabase.from("messages").insert({
+          sender_id: hostUserId,
+          playgroup_id: playgroupId,
+          content: body,
+        });
+      }
+
+      return { error: null };
+    },
+    [playgroupId]
+  );
 
   // The next upcoming session (first in the sorted list)
   const nextSession = sessions.length > 0 ? sessions[0] : null;
@@ -95,7 +132,8 @@ export default function useSessions(playgroupId) {
     nextSession,
     loading,
     createSession,
-    deleteSession,
+    cancelSession,
+    countRsvps,
     refetch: fetchSessions,
   };
 }

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -6,6 +6,7 @@ import { supabase } from "../../lib/supabase";
 import { useSubscription } from "../../hooks/useSubscription";
 import RequestCard from "../../components/host/RequestCard";
 import ScheduleSessionSheet from "../../components/host/ScheduleSessionSheet";
+import CancelSessionSheet from "../../components/playgroup/CancelSessionSheet";
 import useSessions from "../../hooks/useSessions";
 import useReviews from "../../hooks/useReviews";
 import RsvpCount from "../../components/host/RsvpCount";
@@ -188,8 +189,20 @@ export default function HostDashboard() {
     sessions,
     nextSession,
     createSession,
-    deleteSession,
+    cancelSession,
+    countRsvps,
   } = useSessions(realPlaygroup?.id);
+
+  // Cancel sheet state — keep the target session so the sheet can show
+  // the date label and RSVP count without re-querying on every render.
+  const [cancelTarget, setCancelTarget] = useState(null);
+  const [cancelRsvpCount, setCancelRsvpCount] = useState(0);
+
+  const openCancelSheet = async (session) => {
+    const count = await countRsvps(session.id);
+    setCancelRsvpCount(count);
+    setCancelTarget(session);
+  };
 
   // Reviews
   const { reviews, ratings } = useReviews(realPlaygroup?.id);
@@ -595,11 +608,7 @@ export default function HostDashboard() {
               </h3>
               <div className="flex items-center gap-3">
                 <button
-                  onClick={() => {
-                    if (confirm("Cancel this session? This cannot be undone.")) {
-                      deleteSession(nextSession.id);
-                    }
-                  }}
+                  onClick={() => openCancelSheet(nextSession)}
                   className="text-taupe/50 hover:text-terracotta transition-colors bg-transparent border-none cursor-pointer p-0.5"
                   title="Cancel session"
                   aria-label="Cancel session"
@@ -694,7 +703,7 @@ export default function HostDashboard() {
                       </div>
                     </div>
                     <button
-                      onClick={() => deleteSession(session.id)}
+                      onClick={() => openCancelSheet(session)}
                       className="text-taupe/40 hover:text-terracotta transition-colors bg-transparent border-none cursor-pointer p-1"
                       title="Cancel session"
                     >
@@ -967,6 +976,22 @@ export default function HostDashboard() {
           });
           return result;
         }}
+      />
+
+      <CancelSessionSheet
+        isOpen={!!cancelTarget}
+        onClose={() => setCancelTarget(null)}
+        rsvpCount={cancelRsvpCount}
+        sessionDateLabel={
+          cancelTarget ? friendlyDate(cancelTarget.scheduled_at) : ""
+        }
+        onConfirm={(reason) =>
+          cancelSession(cancelTarget.id, {
+            reason,
+            hostUserId: user.id,
+            sessionDateLabel: friendlyDate(cancelTarget.scheduled_at),
+          })
+        }
       />
     </div>
   );

--- a/supabase/migrations/20260418000001_session_soft_cancel.sql
+++ b/supabase/migrations/20260418000001_session_soft_cancel.sql
@@ -1,0 +1,15 @@
+-- Soft-cancel for sessions.
+--
+-- Hosts previously hard-deleted sessions via the X on the Next Session
+-- card. That cascaded the RSVPs and left us with no audit trail, no
+-- reason, and no way to tell the RSVP'd parents why the session went
+-- away. We now mark sessions as cancelled in place, preserve RSVPs,
+-- and post a system message in the group chat so parents are notified.
+
+alter table public.sessions
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists cancel_reason text;
+
+create index if not exists sessions_active_idx
+  on public.sessions (playgroup_id, scheduled_at)
+  where cancelled_at is null;


### PR DESCRIPTION
## Summary
- Soft-cancel replaces hard delete: `cancelled_at` + `cancel_reason` columns on sessions
- New `CancelSessionSheet` replaces the native `confirm()`, shows "N families are RSVP'd" and an optional reason field
- On confirm: session hidden from schedule + a system message posted in the group chat so RSVP'd parents get notified via the existing unread-badge flow

## Migration
Run in Supabase SQL editor **before merging to prod**:

\`\`\`sql
alter table public.sessions
  add column if not exists cancelled_at timestamptz,
  add column if not exists cancel_reason text;
create index if not exists sessions_active_idx
  on public.sessions (playgroup_id, scheduled_at)
  where cancelled_at is null;
\`\`\`

## Test plan
- [ ] Apply the migration
- [ ] Host creates a session, parent RSVPs
- [ ] Host clicks X → sheet shows "1 family is RSVP'd"
- [ ] Host types reason, confirms
- [ ] Parent sees unread badge on the group chat; message reads "🚫 The [date] session was cancelled. [reason]"

🤖 Generated with [Claude Code](https://claude.com/claude-code)