### PR TITLE
Hide Manage Children from host profile menu

### DIFF
--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -111,7 +111,9 @@ export default function MyProfile() {
                 }]
               : []),
             { icon: "\ud83d\udc64", label: "Edit Profile", path: "/edit-profile" },
-            { icon: "\ud83d\udc76", label: "Manage Children", path: "/edit-profile#children" },
+            ...(isHost
+              ? []
+              : [{ icon: "\ud83d\udc76", label: "Manage Children", path: "/edit-profile#children" }]),
             { icon: "\ud83d\udd14", label: "Notifications", path: "/notifications" },
             { icon: "\ud83d\udcdc", label: "Terms of Service", path: "/terms" },
             { icon: "\ud83d\udee1\ufe0f", label: "Privacy Policy", path: "/privacy" },


### PR DESCRIPTION
## Summary
- Removes "Manage Children" from MyProfile menu when the user is a host
- Children remain editable through Edit Profile for the edge case of a host joining someone else's group as a parent

## Test plan
- [ ] As host, MyProfile no longer shows Manage Children
- [ ] As parent, Manage Children still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)