### PR TITLE
Hide Kids/Groups strip on organizer ProfilePanel

### DIFF
--- a/frontend/src/components/profile/ProfilePanel.jsx
+++ b/frontend/src/components/profile/ProfilePanel.jsx
@@ -63,18 +63,25 @@ export default function ProfilePanel({ profile, onMessage }) {
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-2 text-center bg-white rounded-xl border border-cream-dark py-3 mb-4">
-        <div>
-          <div className="text-base font-bold text-charcoal">{profile.children?.length ?? 0}</div>
-          <div className="text-[9px] uppercase text-taupe">Kids</div>
-        </div>
-        <div className="border-l border-cream-dark">
-          <div className="text-base font-bold text-charcoal">{profile.groups_joined_count ?? 0}</div>
-          <div className="text-[9px] uppercase text-taupe">Groups</div>
-        </div>
-      </div>
+      {/* Kids/Groups only make sense for parent profiles. Organizers
+          use the Organizer pill + zip as their at-a-glance info; a
+          "0 kids" on a host profile is misleading, not informative. */}
+      {profile.account_type !== "organizer" && (
+        <>
+          <div className="grid grid-cols-2 gap-2 text-center bg-white rounded-xl border border-cream-dark py-3 mb-4">
+            <div>
+              <div className="text-base font-bold text-charcoal">{profile.children?.length ?? 0}</div>
+              <div className="text-[9px] uppercase text-taupe">Kids</div>
+            </div>
+            <div className="border-l border-cream-dark">
+              <div className="text-base font-bold text-charcoal">{profile.groups_joined_count ?? 0}</div>
+              <div className="text-[9px] uppercase text-taupe">Groups</div>
+            </div>
+          </div>
 
-      <ChildrenCard children={profile.children} />
+          <ChildrenCard children={profile.children} />
+        </>
+      )}
 
       {profile.bio && (
         <div className="mb-4">

--- a/frontend/src/components/profile/ProfilePanel.test.jsx
+++ b/frontend/src/components/profile/ProfilePanel.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import ProfilePanel from "./ProfilePanel";
 
-const sample = {
+const organizerSample = {
   id: "p1",
   first_name: "Priya",
   last_name: "Sharma",
@@ -15,21 +15,30 @@ const sample = {
   groups_joined_count: 2,
 };
 
+const parentSample = { ...organizerSample, account_type: "parent" };
+
 test("renders name, verified label, role label", () => {
-  render(<ProfilePanel profile={sample} />);
+  render(<ProfilePanel profile={organizerSample} />);
   expect(screen.getByText("Priya Sharma")).toBeInTheDocument();
   expect(screen.getByText(/verified parent|verified family|verified organizer/i)).toBeInTheDocument();
   expect(screen.getByText("Organizer")).toBeInTheDocument();
 });
 
 test("does not render tenure, rating, or groups-in-common (v1 deferred)", () => {
-  render(<ProfilePanel profile={sample} />);
+  render(<ProfilePanel profile={organizerSample} />);
   expect(screen.queryByText(/on kiddaboo/i)).not.toBeInTheDocument();
   expect(screen.queryByText(/⭐/)).not.toBeInTheDocument();
   expect(screen.queryByText(/in common/i)).not.toBeInTheDocument();
 });
 
-test("renders children card", () => {
-  render(<ProfilePanel profile={sample} />);
+test("renders children card for parent profiles", () => {
+  render(<ProfilePanel profile={parentSample} />);
   expect(screen.getByText(/Maya/)).toBeInTheDocument();
+});
+
+test("hides kids/groups stats and children card for organizer profiles", () => {
+  render(<ProfilePanel profile={organizerSample} />);
+  expect(screen.queryByText("Kids")).not.toBeInTheDocument();
+  expect(screen.queryByText("Groups")).not.toBeInTheDocument();
+  expect(screen.queryByText(/Maya/)).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Suppresses the Kids/Groups stat strip and ChildrenCard on ProfilePanel when `account_type === "organizer"`
- Organizer pill + zip remain as the at-a-glance info for hosts

## Test plan
- [x] ProfilePanel tests updated and pass (9/9)
- [ ] As host in preview mode, tap own member card → no Kids/Groups strip
- [ ] Parent profiles unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)