### PR TITLE
Add edit-session workflow for hosts

### DIFF
--- a/frontend/src/components/host/ScheduleSessionSheet.jsx
+++ b/frontend/src/components/host/ScheduleSessionSheet.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Button from "../ui/Button";
 import { todayDateString } from "../../lib/dateUtils";
 
@@ -9,13 +9,33 @@ const DURATION_OPTIONS = [
   { label: "3 hrs", value: 180 },
 ];
 
+// Splits a scheduled_at ISO string into local date (YYYY-MM-DD) and
+// time (HH:MM) parts for the form inputs. Using the raw substring of
+// the ISO would be wrong because scheduled_at is UTC and inputs are
+// local — a 10 AM EST session comes back as 14:00Z and would prefill
+// the time as 14:00.
+function splitLocal(iso) {
+  const d = new Date(iso);
+  const pad = (n) => String(n).padStart(2, "0");
+  return {
+    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
 export default function ScheduleSessionSheet({
   isOpen,
   onClose,
   defaultLocation = "",
   playgroupName = "",
   onSchedule,
+  // When provided, the sheet switches to edit mode: prefills from the
+  // existing session and routes submit through onUpdate instead of
+  // onSchedule. Copy and button labels shift accordingly.
+  existingSession = null,
+  onUpdate,
 }) {
+  const isEdit = !!existingSession;
   const [date, setDate] = useState("");
   const [time, setTime] = useState("10:00");
   const [duration, setDuration] = useState(120);
@@ -24,6 +44,19 @@ export default function ScheduleSessionSheet({
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [confirmOvernight, setConfirmOvernight] = useState(false);
+
+  // Prefill when opening in edit mode. Guarded on isOpen so the form
+  // resets to the current session's values every time the sheet is
+  // re-opened — not the last edit state.
+  useEffect(() => {
+    if (!isOpen || !existingSession) return;
+    const { date: d, time: t } = splitLocal(existingSession.scheduled_at);
+    setDate(d);
+    setTime(t);
+    setDuration(existingSession.duration_minutes || 120);
+    setLocation(existingSession.location_name || "");
+    setNotes(existingSession.notes || "");
+  }, [isOpen, existingSession]);
 
   const canSubmit = date && time && !saving;
 
@@ -45,22 +78,20 @@ export default function ScheduleSessionSheet({
   const submit = async () => {
     setSaving(true);
 
-    // Combine date + time into ISO string
     const scheduledAt = new Date(`${date}T${time}:00`).toISOString();
-
-    const result = await onSchedule?.({
-      title: playgroupName || "Playdate",
+    const payload = {
       scheduled_at: scheduledAt,
       duration_minutes: duration,
       location_name: location || null,
       notes: notes || null,
-    });
+    };
+
+    const result = isEdit
+      ? await onUpdate?.(payload, existingSession)
+      : await onSchedule?.({ title: playgroupName || "Playdate", ...payload });
 
     setSaving(false);
-
-    if (!result?.error) {
-      setSuccess(true);
-    }
+    if (!result?.error) setSuccess(true);
   };
 
   const handleSchedule = async () => {
@@ -157,10 +188,12 @@ export default function ScheduleSessionSheet({
                 </svg>
               </div>
               <h3 className="text-xl font-heading font-bold text-charcoal mb-2">
-                Session scheduled!
+                {isEdit ? "Session updated!" : "Session scheduled!"}
               </h3>
               <p className="text-sm text-taupe leading-relaxed mb-6">
-                Your group members will be able to see this on the playgroup page.
+                {isEdit
+                  ? "Anyone who RSVP'd will get a message in the group chat."
+                  : "Your group members will be able to see this on the playgroup page."}
               </p>
               <Button variant="secondary" onClick={handleClose}>
                 Done
@@ -170,10 +203,12 @@ export default function ScheduleSessionSheet({
             /* Schedule form */
             <>
               <h3 className="text-xl font-heading font-bold text-charcoal mb-1">
-                Schedule a session
+                {isEdit ? "Edit session" : "Schedule a session"}
               </h3>
               <p className="text-sm text-taupe mb-6">
-                Pick a date and time for your next playdate.
+                {isEdit
+                  ? "Update the details below. RSVP'd families will be notified."
+                  : "Pick a date and time for your next playdate."}
               </p>
 
               {/* Date */}
@@ -286,7 +321,7 @@ export default function ScheduleSessionSheet({
                 disabled={!canSubmit}
                 loading={saving}
               >
-                Schedule Session
+                {isEdit ? "Save changes" : "Schedule Session"}
               </Button>
             </>
           )}

--- a/frontend/src/hooks/useSessions.js
+++ b/frontend/src/hooks/useSessions.js
@@ -74,6 +74,42 @@ export default function useSessions(playgroupId) {
     [playgroupId]
   );
 
+  // Update an existing session. Mirrors cancelSession in shape: the
+  // caller can pass hostUserId + sessionDateLabel so we post a system
+  // message in the group chat when RSVP'd parents are affected by the
+  // change. "What changed" is summarized by the caller, since it knows
+  // which fields they edited.
+  const updateSession = useCallback(
+    async (sessionId, updates, { hostUserId, changeSummary } = {}) => {
+      const { data, error } = await supabase
+        .from("sessions")
+        .update(updates)
+        .eq("id", sessionId)
+        .select()
+        .single();
+
+      if (error) return { error };
+
+      setSessions((prev) => {
+        const next = prev.map((s) => (s.id === sessionId ? data : s));
+        return next.sort(
+          (a, b) => new Date(a.scheduled_at) - new Date(b.scheduled_at)
+        );
+      });
+
+      if (playgroupId && hostUserId && changeSummary) {
+        await supabase.from("messages").insert({
+          sender_id: hostUserId,
+          playgroup_id: playgroupId,
+          content: `📅 Session updated. ${changeSummary}`,
+        });
+      }
+
+      return { data, error: null };
+    },
+    [playgroupId]
+  );
+
   // Count RSVPs on a session so the host can see who will be affected
   // before confirming a cancellation. "going" matches useRsvps — we
   // don't surface "maybe" / "can't" in the count because cancellation
@@ -132,6 +168,7 @@ export default function useSessions(playgroupId) {
     nextSession,
     loading,
     createSession,
+    updateSession,
     cancelSession,
     countRsvps,
     refetch: fetchSessions,

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -189,6 +189,7 @@ export default function HostDashboard() {
     sessions,
     nextSession,
     createSession,
+    updateSession,
     cancelSession,
     countRsvps,
   } = useSessions(realPlaygroup?.id);
@@ -197,6 +198,9 @@ export default function HostDashboard() {
   // the date label and RSVP count without re-querying on every render.
   const [cancelTarget, setCancelTarget] = useState(null);
   const [cancelRsvpCount, setCancelRsvpCount] = useState(0);
+
+  // Edit sheet state — when set, ScheduleSessionSheet opens in edit mode.
+  const [editTarget, setEditTarget] = useState(null);
 
   const openCancelSheet = async (session) => {
     const count = await countRsvps(session.id);
@@ -608,6 +612,17 @@ export default function HostDashboard() {
               </h3>
               <div className="flex items-center gap-3">
                 <button
+                  onClick={() => setEditTarget(nextSession)}
+                  className="text-taupe/50 hover:text-sage-dark transition-colors bg-transparent border-none cursor-pointer p-0.5"
+                  title="Edit session"
+                  aria-label="Edit session"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                    <path d="M12 20h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    <path d="M16.5 3.5a2.121 2.121 0 113 3L7 19l-4 1 1-4 12.5-12.5z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+                <button
                   onClick={() => openCancelSheet(nextSession)}
                   className="text-taupe/50 hover:text-terracotta transition-colors bg-transparent border-none cursor-pointer p-0.5"
                   title="Cancel session"
@@ -702,15 +717,29 @@ export default function HostDashboard() {
                         </p>
                       </div>
                     </div>
-                    <button
-                      onClick={() => openCancelSheet(session)}
-                      className="text-taupe/40 hover:text-terracotta transition-colors bg-transparent border-none cursor-pointer p-1"
-                      title="Cancel session"
-                    >
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                        <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                      </svg>
-                    </button>
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => setEditTarget(session)}
+                        className="text-taupe/40 hover:text-sage-dark transition-colors bg-transparent border-none cursor-pointer p-1"
+                        title="Edit session"
+                        aria-label="Edit session"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                          <path d="M12 20h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                          <path d="M16.5 3.5a2.121 2.121 0 113 3L7 19l-4 1 1-4 12.5-12.5z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => openCancelSheet(session)}
+                        className="text-taupe/40 hover:text-terracotta transition-colors bg-transparent border-none cursor-pointer p-1"
+                        title="Cancel session"
+                        aria-label="Cancel session"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                          <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                   <RsvpCount sessionId={session.id} />
                 </div>
@@ -975,6 +1004,43 @@ export default function HostDashboard() {
             created_by: user.id,
           });
           return result;
+        }}
+      />
+
+      {/* Edit session bottom sheet — reuses ScheduleSessionSheet in edit
+          mode. Separate instance from the schedule sheet so open/close
+          state is independent. */}
+      <ScheduleSessionSheet
+        isOpen={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        defaultLocation={realPlaygroup?.location_name || ""}
+        playgroupName={realPlaygroup?.name || ""}
+        existingSession={editTarget}
+        onUpdate={async (updates, prev) => {
+          const parts = [];
+          if (updates.scheduled_at !== prev.scheduled_at) {
+            parts.push(
+              `Now ${friendlyDate(updates.scheduled_at)} at ${formatSessionTime(updates.scheduled_at)}.`
+            );
+          }
+          if (updates.duration_minutes !== prev.duration_minutes) {
+            parts.push(`Duration ${formatDuration(updates.duration_minutes)}.`);
+          }
+          if ((updates.location_name || "") !== (prev.location_name || "")) {
+            parts.push(
+              updates.location_name
+                ? `Location: ${updates.location_name}.`
+                : `Location cleared.`
+            );
+          }
+          if ((updates.notes || "") !== (prev.notes || "")) {
+            parts.push(`Notes updated.`);
+          }
+          const rsvpCount = await countRsvps(prev.id);
+          return updateSession(prev.id, updates, {
+            hostUserId: user.id,
+            changeSummary: rsvpCount > 0 && parts.length > 0 ? parts.join(" ") : null,
+          });
         }}
       />
 


### PR DESCRIPTION
## Summary
- New \`updateSession\` in useSessions
- ScheduleSessionSheet accepts \`existingSession\` + \`onUpdate\` and switches to edit mode (prefill, copy, button label)
- Pencil button added next to X on both Next Session card and Upcoming Sessions rows
- When RSVPs > 0 and fields changed, posts a "📅 Session updated. [summary]" system message in group chat

## Test plan
- [ ] Host edits a session with no RSVPs → no chat message
- [ ] Host edits a session with RSVPs → chat message describes what changed
- [ ] Time, date, duration, location, notes all editable
- [ ] Cancelling the sheet resets to latest session values (not last edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)