### PR TITLE
Add to Calendar for RSVP'd parents

### DIFF
--- a/frontend/src/components/playgroup/SessionCard.jsx
+++ b/frontend/src/components/playgroup/SessionCard.jsx
@@ -1,8 +1,26 @@
 import { useState } from "react";
 import useRsvps from "../../hooks/useRsvps";
 import { friendlyDate, formatSessionTime, formatDuration } from "../../lib/dateUtils";
+import { downloadIcs } from "../../lib/icsExport";
 
-function RsvpButtons({ sessionId }) {
+function AddToCalendarButton({ session, playgroupName }) {
+  return (
+    <button
+      onClick={() => downloadIcs({ session, playgroupName })}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-150 cursor-pointer border bg-white text-taupe-dark border-cream-dark hover:border-sage"
+      title="Add to your phone's calendar"
+    >
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+        <rect x="3" y="5" width="18" height="16" rx="2" stroke="currentColor" strokeWidth="2" />
+        <path d="M3 9H21M8 3V7M16 3V7M12 13V17M10 15H14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+      Add to calendar
+    </button>
+  );
+}
+
+function RsvpButtons({ session, playgroupName }) {
+  const sessionId = session.id;
   const { myRsvp, goingCount, upsertRsvp, deleteRsvp } = useRsvps(sessionId);
   const [saving, setSaving] = useState(false);
 
@@ -61,6 +79,8 @@ function RsvpButtons({ sessionId }) {
         </svg>
         Can't make it
       </button>
+
+      {isGoing && <AddToCalendarButton session={session} playgroupName={playgroupName} />}
     </div>
   );
 }
@@ -72,6 +92,7 @@ export default function SessionCard({
   ageRange,
   showRsvp = false,
   variant = "featured",
+  playgroupName,
 }) {
   if (variant === "compact") {
     return (
@@ -93,7 +114,7 @@ export default function SessionCard({
             </p>
           </div>
         </div>
-        {showRsvp && <RsvpButtons sessionId={session.id} />}
+        {showRsvp && <RsvpButtons session={session} playgroupName={playgroupName} />}
       </div>
     );
   }
@@ -127,7 +148,7 @@ export default function SessionCard({
         </p>
       )}
 
-      {showRsvp && <RsvpButtons sessionId={session.id} />}
+      {showRsvp && <RsvpButtons session={session} playgroupName={playgroupName} />}
 
       <div className="mt-3 pt-3 border-t border-cream-dark">
         <p className="text-xs text-taupe">

--- a/frontend/src/lib/icsExport.js
+++ b/frontend/src/lib/icsExport.js
@@ -1,0 +1,81 @@
+// Build a .ics (iCalendar) file for a session and trigger a download.
+// .ics is the universal format — tapping the download on iOS opens
+// Apple Calendar, on Android it opens Google Calendar, on desktop it
+// opens whichever app is registered. No backend or OAuth needed.
+
+// Format a Date as a UTC timestamp in iCalendar form: 20260501T143000Z
+function toIcsUtc(date) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return (
+    date.getUTCFullYear() +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    "T" +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds()) +
+    "Z"
+  );
+}
+
+// RFC 5545 requires commas, semicolons, backslashes, and newlines in
+// text fields to be escaped. Without this, a note like "Bring snacks;
+// sunscreen" would corrupt the file.
+function escapeText(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+}
+
+export function buildIcs({ session, playgroupName }) {
+  const start = new Date(session.scheduled_at);
+  const end = new Date(start.getTime() + (session.duration_minutes || 60) * 60000);
+
+  const title = playgroupName
+    ? `${playgroupName} playdate`
+    : session.title || "Playdate";
+
+  const descParts = [];
+  if (playgroupName) descParts.push(`Kiddaboo playgroup: ${playgroupName}`);
+  if (session.notes) descParts.push(session.notes);
+
+  // UID must be stable + unique so calendars dedupe on re-download.
+  const uid = `session-${session.id}@kiddaboo`;
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Kiddaboo//Session//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${toIcsUtc(new Date())}`,
+    `DTSTART:${toIcsUtc(start)}`,
+    `DTEND:${toIcsUtc(end)}`,
+    `SUMMARY:${escapeText(title)}`,
+  ];
+  if (session.location_name) lines.push(`LOCATION:${escapeText(session.location_name)}`);
+  if (descParts.length > 0) lines.push(`DESCRIPTION:${escapeText(descParts.join("\n"))}`);
+  lines.push("END:VEVENT", "END:VCALENDAR");
+
+  // CRLF line endings are part of the RFC 5545 spec; some strict
+  // parsers (older Outlook versions) reject plain \n.
+  return lines.join("\r\n");
+}
+
+export function downloadIcs({ session, playgroupName }) {
+  const ics = buildIcs({ session, playgroupName });
+  const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `kiddaboo-session-${session.id}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Give Safari a tick before revoking — it can race the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/frontend/src/lib/icsExport.test.js
+++ b/frontend/src/lib/icsExport.test.js
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "vitest";
+import { buildIcs } from "./icsExport";
+
+const baseSession = {
+  id: "abc-123",
+  scheduled_at: "2026-05-01T14:30:00Z",
+  duration_minutes: 90,
+  location_name: "Central Park playground",
+  notes: "Bring sunscreen",
+  title: "Playdate",
+};
+
+describe("buildIcs", () => {
+  test("includes required iCalendar envelope + VEVENT fields", () => {
+    const ics = buildIcs({ session: baseSession, playgroupName: "Westside Toddlers" });
+    expect(ics).toMatch(/^BEGIN:VCALENDAR\r\n/);
+    expect(ics).toMatch(/END:VCALENDAR$/);
+    expect(ics).toContain("BEGIN:VEVENT");
+    expect(ics).toContain("END:VEVENT");
+    expect(ics).toContain("UID:session-abc-123@kiddaboo");
+    expect(ics).toContain("SUMMARY:Westside Toddlers playdate");
+  });
+
+  test("computes DTEND from duration_minutes", () => {
+    const ics = buildIcs({ session: baseSession });
+    expect(ics).toContain("DTSTART:20260501T143000Z");
+    expect(ics).toContain("DTEND:20260501T160000Z");
+  });
+
+  test("escapes commas, semicolons, and newlines in text fields", () => {
+    const ics = buildIcs({
+      session: { ...baseSession, notes: "Bring snacks; sunscreen, hats\nmeet at gate" },
+    });
+    expect(ics).toContain("Bring snacks\\; sunscreen\\, hats\\nmeet at gate");
+  });
+
+  test("omits LOCATION and DESCRIPTION when empty", () => {
+    const ics = buildIcs({
+      session: { ...baseSession, location_name: null, notes: null },
+    });
+    expect(ics).not.toContain("LOCATION:");
+    expect(ics).not.toContain("DESCRIPTION:");
+  });
+
+  test("uses CRLF line endings per RFC 5545", () => {
+    const ics = buildIcs({ session: baseSession });
+    expect(ics.split("\r\n").length).toBeGreaterThan(5);
+    expect(ics).not.toMatch(/[^\r]\n/);
+  });
+});

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -427,6 +427,7 @@ export default function PlaygroupDetail() {
                 ageRange={group.ageRange}
                 showRsvp={joinStatus === "member"}
                 variant="featured"
+                playgroupName={group.name}
               />
 
               {/* Additional upcoming sessions */}
@@ -439,6 +440,7 @@ export default function PlaygroupDetail() {
                   ageRange={group.ageRange}
                   showRsvp={joinStatus === "member"}
                   variant="compact"
+                  playgroupName={group.name}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- New `icsExport.js` helper builds an RFC 5545 .ics blob from a session and triggers a download
- "Add to calendar" button appears on `SessionCard` only when the parent has RSVP'd "going" (both compact + featured variants)
- Tapping on mobile opens the native calendar (iOS Calendar, Google Calendar, Outlook) pre-filled with title, time, duration, location, notes — no backend, no OAuth

## Test plan
- [x] Unit tests for `buildIcs` (envelope, DTEND from duration, text escaping, optional fields, CRLF line endings)
- [ ] RSVP "going" on a session in live site → button appears → tap downloads .ics → opens in native calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)