### PR TITLE
Guard authed routes behind phone verification

### DIFF
--- a/frontend/src/components/auth/RequireAuth.jsx
+++ b/frontend/src/components/auth/RequireAuth.jsx
@@ -1,8 +1,21 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 
+// Routes a half-authenticated user (signed up + email confirmed, but
+// phone OTP never completed) is allowed to reach. Without this list
+// we'd bounce them into /verify-phone even when they ARE on
+// /verify-phone, causing a render loop. /profile and /children are
+// part of the create-profile onboarding step that runs *before*
+// phone verification in the happy path, so we let them through too.
+const PHONE_VERIFY_EXEMPT = new Set([
+  "/verify-phone",
+  "/profile",
+  "/children",
+]);
+
 export default function RequireAuth({ children }) {
-  const { user, loading } = useAuth();
+  const { user, profile, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -14,6 +27,18 @@ export default function RequireAuth({ children }) {
 
   if (!user) {
     return <Navigate to="/" replace />;
+  }
+
+  // If the profile has loaded and phone is not yet verified, funnel
+  // the user back into PhoneVerify. We only act once profile is
+  // non-null — otherwise a slow profile fetch would bounce the user
+  // to /verify-phone before we even know their state.
+  if (
+    profile &&
+    !profile.phone_verified_at &&
+    !PHONE_VERIFY_EXEMPT.has(location.pathname)
+  ) {
+    return <Navigate to="/verify-phone" replace />;
   }
 
   return children;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }) {
   const fetchProfile = async (userId) => {
     const { data, error } = await supabase
       .from("profiles")
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role, account_type")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type")
       .eq("id", userId)
       .single();
 
@@ -108,7 +108,7 @@ export function AuthProvider({ children }) {
       .from("profiles")
       .update({ ...updates, updated_at: new Date().toISOString() })
       .eq("id", user.id)
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, created_at, updated_at, notification_prefs, role, account_type")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type")
       .single();
 
     if (error) {


### PR DESCRIPTION
## Summary
- Parents with `email_confirmed_at` set but `phone_verified_at = null` could slip into `/browse` and the rest of the app without finishing phone OTP — they'd only hit the gate when trying to Join a group
- `RequireAuth` now redirects any signed-in user with `phone_verified_at = null` to `/verify-phone`
- Exempt paths: `/verify-phone`, `/profile`, `/children` (pre-verification onboarding steps)
- Also adds `phone_verified_at` to the AuthContext profile fetch

## Test plan
- [x] 100/100 regression tests green
- [ ] Existing verified user signs in → goes to `/browse` as before
- [ ] Half-authed user (like Pathma) signs in → lands on `/verify-phone` automatically
- [ ] On `/verify-phone`, no redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)