### PR TITLE
Parent workflow fixes: members refresh, meter copy, verified badge

### DIFF
--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -59,6 +59,14 @@ export default function MyProfile() {
           <h2 className="text-lg font-heading font-bold text-charcoal">
             {firstName} {lastName}
           </h2>
+          {profile?.phone_verified_at && (
+            <span className="inline-flex items-center gap-1 mt-1.5 text-[11px] text-sage-dark bg-sage-light px-2 py-0.5 rounded-full">
+              <svg width="10" height="10" viewBox="0 0 20 20" fill="none">
+                <path d="M5 10l3 3 7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Phone verified
+            </span>
+          )}
           {user?.email && (
             <p className="text-xs text-taupe mt-1">{user.email}</p>
           )}

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PhotoCarousel from "../components/playgroup/PhotoCarousel";
 import EnvironmentChecklist from "../components/playgroup/EnvironmentChecklist";
@@ -126,34 +126,35 @@ export default function PlaygroupDetail() {
   } = useReviews(id);
 
   // Try fetching from Supabase first
-  useEffect(() => {
-    const fetchGroup = async () => {
-      const { data, error } = await supabase
-        .from("playgroups")
-        .select(`
-          *,
-          profiles:creator_id ( first_name, last_name, bio, philosophy_tags, is_verified, trust_score ),
-          memberships ( user_id, role, profiles:user_id ( first_name, last_name, phone_verified_at, bio, philosophy_tags, account_type, zip_code, photo_url ) )
-        `)
-        .eq("id", id)
-        .single();
+  const fetchGroup = useCallback(async () => {
+    const { data, error } = await supabase
+      .from("playgroups")
+      .select(`
+        *,
+        profiles:creator_id ( first_name, last_name, bio, philosophy_tags, is_verified, trust_score ),
+        memberships ( user_id, role, profiles:user_id ( first_name, last_name, phone_verified_at, bio, philosophy_tags, account_type, zip_code, photo_url ) )
+      `)
+      .eq("id", id)
+      .single();
 
-      if (!error && data) {
-        setRealGroup(transformRealPlaygroup(data));
+    if (!error && data) {
+      setRealGroup(transformRealPlaygroup(data));
 
-        // In preview mode, don't reflect the host's own "creator" status —
-        // we want to see the parent CTA as a parent would.
-        if (user && !previewMode) {
-          const existing = (data.memberships || []).find(
-            (m) => m.user_id === user.id
-          );
-          if (existing) setJoinStatus(existing.role);
-        }
+      // In preview mode, don't reflect the host's own "creator" status —
+      // we want to see the parent CTA as a parent would.
+      if (user && !previewMode) {
+        const existing = (data.memberships || []).find(
+          (m) => m.user_id === user.id
+        );
+        if (existing) setJoinStatus(existing.role);
       }
-      setLoading(false);
-    };
-    fetchGroup();
+    }
+    setLoading(false);
   }, [id, user, previewMode]);
+
+  useEffect(() => {
+    fetchGroup();
+  }, [fetchGroup]);
 
   // Track playgroup view for host analytics (deduplicated hourly)
   useEffect(() => {
@@ -222,6 +223,7 @@ export default function PlaygroupDetail() {
         setJoinStatus("member");
         setJoinError("");
         setJoinMessage("You're in! Say hi in the group chat.");
+        fetchGroup();
       } else {
         setJoinMessage("");
         setJoinError("Something went wrong joining this group. Please try again.");
@@ -248,6 +250,7 @@ export default function PlaygroupDetail() {
 
     if (!error) {
       setJoinStatus("pending");
+      fetchGroup();
     }
     return { error: error || null };
   };
@@ -661,7 +664,7 @@ export default function PlaygroupDetail() {
               </Button>
               {!isPremium && user && (
                 <p className="text-[11px] text-taupe/60 text-center mt-2">
-                  {joinRequestsRemaining} of {joinRequestLimit} free requests remaining
+                  {joinRequestsRemaining} of {joinRequestLimit} free requests left this month
                 </p>
               )}
             </>
@@ -711,7 +714,7 @@ export default function PlaygroupDetail() {
                 </svg>
               </div>
               <h3 className="font-heading font-bold text-charcoal text-lg mb-2">
-                You've used all {joinRequestLimit} free requests
+                You've used all {joinRequestLimit} free requests this month
               </h3>
               <p className="text-sm text-taupe leading-relaxed mb-5">
                 Upgrade to Premium for unlimited join requests, advanced filters, and priority placement.


### PR DESCRIPTION
## Summary
Three small fixes from a parent-workflow audit:

- **Members list refresh after join** — `PlaygroupDetail` was inserting the membership but never refetching, so the Members section stayed stale (showing only the organizer) until the page was reloaded. Now refetches on success.
- **Metering copy alignment** — Premium says "1 join request / month" but the meter on Playgroup Detail said "1 of 1 free requests remaining" with no time framing. Updated to "left this month" / "all 1 free requests this month".
- **Phone verified pill on My Profile** — PR #88 gated authed routes on phone verification but the parent never sees their verified status. Added a small "Phone verified" pill under the name.

## Test plan
- [ ] Vitest suite (100 tests) still passes locally
- [ ] On a fresh parent account, joining an open playgroup immediately shows the parent in the Members list without a manual reload
- [ ] Free meter on Playgroup Detail reads "left this month" and the upgrade modal reads "all 1 free requests this month"
- [ ] My Profile shows the green "Phone verified" pill for a verified parent and hides it for an unverified one

🤖 Generated with [Claude Code](https://claude.com/claude-code)