### PR TITLE
Parent audit batch 2: badge wrap, hide stub, bio validation

### DIFF
--- a/frontend/src/components/browse/PlaygroupCard.jsx
+++ b/frontend/src/components/browse/PlaygroupCard.jsx
@@ -28,7 +28,7 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
                 style={{ backgroundColor: group.photoColor + "40" }}
               />
             )}
-            <div className="absolute top-4 left-4 flex gap-2">
+            <div className="absolute top-4 left-4 right-4 flex flex-wrap gap-2">
               <span className="px-3 py-1 bg-amber-400/90 backdrop-blur-md rounded-full text-[10px] font-bold tracking-widest uppercase text-white">
                 Premium
               </span>
@@ -158,7 +158,7 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
             style={{ backgroundColor: group.photoColor + "40" }}
           />
         )}
-        <div className="absolute top-3 left-3 flex gap-1.5">
+        <div className="absolute top-3 left-3 right-3 flex flex-wrap gap-1.5">
           {premium && (
             <span className="px-3 py-1 bg-amber-400/90 backdrop-blur-md rounded-full text-[10px] font-bold tracking-widest uppercase text-white">
               Premium

--- a/frontend/src/pages/EditProfile.jsx
+++ b/frontend/src/pages/EditProfile.jsx
@@ -171,6 +171,18 @@ export default function EditProfile() {
       return;
     }
 
+    const trimmedBio = bio.trim();
+    if (trimmedBio) {
+      if (trimmedBio.length < 10) {
+        setError("Tell hosts a little more about your family — at least 10 characters.");
+        return;
+      }
+      if (/^(.)\1+$/i.test(trimmedBio.replace(/\s/g, ""))) {
+        setError("Please write a real bio — repeated characters won't help hosts get to know you.");
+        return;
+      }
+    }
+
     setSaving(true);
     setError("");
     setSaved(false);

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -117,7 +117,6 @@ export default function MyProfile() {
             { icon: "\ud83d\udd14", label: "Notifications", path: "/notifications" },
             { icon: "\ud83d\udcdc", label: "Terms of Service", path: "/terms" },
             { icon: "\ud83d\udee1\ufe0f", label: "Privacy Policy", path: "/privacy" },
-            { icon: "\u2753", label: "Help & Support", comingSoon: true },
           ].map((item, i, arr) => (
             <button
               key={item.label}


### PR DESCRIPTION
## Summary
Three more parent-workflow polish items from the audit:

- **Badge wrap on PlaygroupCard** — the Premium + Open badge row was clipping the second badge on narrow card widths (saw "OP" instead of "OPEN"). Allow the row to wrap.
- **Drop "Help & Support — Soon" stub** — settings menu item that links nowhere; hide until it's real.
- **Bio validation** — reject bios under 10 chars or a single repeated character (e.g. "Xxxxxx") before save.

## Test plan
- [ ] Vitest suite (100 tests) still passes locally
- [ ] On a narrow viewport, both Premium and Open badges fit on a card without truncation
- [ ] My Profile no longer shows the "Help & Support — Soon" row
- [ ] Edit Profile rejects "Xxxxxx" or "aaaa" with a clear error and accepts a real bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)