### PR TITLE
Parent audit batch 3: chat header + title de-dup

### DIFF
--- a/frontend/src/pages/GroupChat.jsx
+++ b/frontend/src/pages/GroupChat.jsx
@@ -16,6 +16,7 @@ export default function GroupChat() {
   const { user } = useAuth();
 
   const [groupName, setGroupName] = useState("");
+  const [groupPhoto, setGroupPhoto] = useState(null);
   // #50: show the group name in the tab once it's loaded so users
   // can tell multiple open chats apart.
   useDocumentTitle(groupName ? `${groupName} chat` : "Chat");
@@ -37,14 +38,17 @@ export default function GroupChat() {
     if (!playgroupId || !user) return;
 
     const fetchGroupInfo = async () => {
-      // Get playgroup name
+      // Get playgroup name + first photo for the header avatar
       const { data: pg } = await supabase
         .from("playgroups")
-        .select("name")
+        .select("name, photos")
         .eq("id", playgroupId)
         .single();
 
-      if (pg) setGroupName(pg.name);
+      if (pg) {
+        setGroupName(pg.name);
+        setGroupPhoto(pg.photos?.[0] || null);
+      }
 
       // Check user is a member/creator. maybeSingle() — non-member users
       // legitimately return 0 rows here; .single() would 406.
@@ -176,14 +180,29 @@ export default function GroupChat() {
             </svg>
           </button>
 
-          <div className="flex-1 min-w-0">
-            <h1 className="font-heading font-bold text-charcoal text-base truncate">
-              {groupName}
-            </h1>
-            <p className="text-[10px] text-taupe">
-              {memberCount} {memberCount === 1 ? "member" : "members"}
-            </p>
-          </div>
+          <button
+            onClick={() => navigate(`/playgroup/${playgroupId}`)}
+            aria-label={`Open ${groupName || "playgroup"} details`}
+            className="flex-1 min-w-0 flex items-center gap-3 bg-transparent border-none p-0 text-left cursor-pointer"
+          >
+            <div className="w-9 h-9 rounded-full bg-sage-light flex items-center justify-center overflow-hidden shrink-0">
+              {groupPhoto ? (
+                <img src={groupPhoto} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-xs font-heading font-bold text-sage-dark">
+                  {(groupName?.[0] || "?").toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h1 className="font-heading font-bold text-charcoal text-base truncate">
+                {groupName}
+              </h1>
+              <p className="text-[10px] text-taupe">
+                {memberCount} {memberCount === 1 ? "member" : "members"} · View details
+              </p>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PhotoCarousel from "../components/playgroup/PhotoCarousel";
 import EnvironmentChecklist from "../components/playgroup/EnvironmentChecklist";
@@ -109,6 +109,22 @@ export default function PlaygroupDetail() {
   const [joinMessage, setJoinMessage] = useState("");
   const [joinError, setJoinError] = useState("");
   const [activeProfile, setActiveProfile] = useState(null);
+  const [titleScrolledOut, setTitleScrolledOut] = useState(false);
+  const inPageTitleRef = useRef(null);
+
+  // Show the title in the sticky top bar only after the in-page heading
+  // has scrolled out of view, so we don't show two copies of the same
+  // title at once on initial load.
+  useEffect(() => {
+    const el = inPageTitleRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setTitleScrolledOut(!entry.isIntersecting),
+      { rootMargin: "-60px 0px 0px 0px", threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [realGroup, previewMode]);
 
   const { blockUser, submitReport } = useBlocks(user?.id);
   const { canSendJoinRequest, joinRequestsRemaining, joinRequestLimit, isPremium, incrementUsage } = useSubscription();
@@ -274,7 +290,12 @@ export default function PlaygroupDetail() {
             />
           </svg>
         </button>
-        <h2 className="font-heading font-bold text-charcoal text-sm truncate flex-1">
+        <h2
+          className={`font-heading font-bold text-charcoal text-sm truncate flex-1 transition-opacity duration-200 ${
+            titleScrolledOut ? "opacity-100" : "opacity-0"
+          }`}
+          aria-hidden={!titleScrolledOut}
+        >
           {group.name}
         </h2>
         {user && group.host?.userId === user.id && previewMode ? (
@@ -356,7 +377,10 @@ export default function PlaygroupDetail() {
         {/* Title + access badge + location */}
         <div className="mb-6">
           <div className="flex items-start justify-between gap-3 mb-2">
-            <h1 className="text-2xl font-heading font-bold text-charcoal">
+            <h1
+              ref={inPageTitleRef}
+              className="text-2xl font-heading font-bold text-charcoal"
+            >
               {group.name}
             </h1>
             <span


### PR DESCRIPTION
## Summary
- GroupChat: avatar in header + tappable title navigates to playgroup detail (so members can reach member list).
- PlaygroupDetail: hide sticky top-bar title until the in-page h1 scrolls out of view, removing duplicate title on load.

## Test plan
- [x] vitest: 100/100 passing
- [ ] On a playgroup detail page, only one title visible at top of page; sticky title appears after scrolling past h1
- [ ] In a group chat, tapping the header navigates to the playgroup detail