### PR TITLE
Parent audit batch 5: data-correctness fixes

### DIFF
--- a/frontend/src/pages/AddChildren.jsx
+++ b/frontend/src/pages/AddChildren.jsx
@@ -28,10 +28,14 @@ export default function AddChildren() {
     setSaving(true);
     setError("");
 
-    // Delete existing children first (in case user goes back and re-does this step)
-    await supabase.from("children").delete().eq("user_id", user.id);
+    // Snapshot existing rows first. We only delete them AFTER the
+    // insert lands — otherwise a transient insert failure would wipe
+    // every existing child record with no way to recover.
+    const { data: existing } = await supabase
+      .from("children")
+      .select("id")
+      .eq("user_id", user.id);
 
-    // Insert all valid children
     const rows = validChildren.map((c) => ({
       user_id: user.id,
       name: c.name.trim(),
@@ -41,13 +45,19 @@ export default function AddChildren() {
 
     const { error: insertError } = await supabase.from("children").insert(rows);
 
-    setSaving(false);
-
     if (insertError) {
+      setSaving(false);
       setError("Could not save. Please try again.");
       return;
     }
 
+    // Insert succeeded — now safe to remove the old rows.
+    const oldIds = (existing || []).map((r) => r.id);
+    if (oldIds.length > 0) {
+      await supabase.from("children").delete().in("id", oldIds);
+    }
+
+    setSaving(false);
     navigate("/success");
   };
 

--- a/frontend/src/pages/MyGroups.jsx
+++ b/frontend/src/pages/MyGroups.jsx
@@ -89,8 +89,11 @@ export default function MyGroups() {
           .select("role")
           .eq("playgroup_id", pg.id);
 
+        // Include the creator in the member count so this matches what
+        // PlaygroupDetail and GroupChat show — otherwise the host's own
+        // group reads as "1 member fewer" everywhere except those pages.
         const memberCount = (pgMembers || []).filter(
-          (m) => m.role === "member"
+          (m) => m.role === "member" || m.role === "creator"
         ).length;
         const pendingCount = (pgMembers || []).filter(
           (m) => m.role === "pending"

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -227,8 +227,10 @@ export default function PlaygroupDetail() {
     }
 
     if (group.accessType === "open") {
-      // Directly join open groups
-      await incrementUsage();
+      // Directly join open groups. Insert first; only burn the user's
+      // monthly free request on success — otherwise a transient DB
+      // failure would silently consume their one free join for the
+      // month with nothing to show for it.
       const { error } = await supabase.from("memberships").insert({
         user_id: user.id,
         playgroup_id: id,
@@ -236,6 +238,7 @@ export default function PlaygroupDetail() {
         joined_at: new Date().toISOString(),
       });
       if (!error) {
+        await incrementUsage();
         setJoinStatus("member");
         setJoinError("");
         setJoinMessage("You're in! Say hi in the group chat.");
@@ -255,7 +258,8 @@ export default function PlaygroupDetail() {
   const handleJoinSubmit = async ({ intro, answers }) => {
     if (!user) return { error: "Not signed in" };
 
-    await incrementUsage();
+    // Insert first; only burn the free monthly request if the row
+    // landed. Avoids consuming the user's quota on transient errors.
     const { error } = await supabase.from("memberships").insert({
       user_id: user.id,
       playgroup_id: id,
@@ -265,6 +269,7 @@ export default function PlaygroupDetail() {
     });
 
     if (!error) {
+      await incrementUsage();
       setJoinStatus("pending");
       fetchGroup();
     }


### PR DESCRIPTION
## Summary
- **MyGroups**: include creator in member count so it matches PlaygroupDetail/GroupChat.
- **PlaygroupDetail**: insert membership before incrementing free-request usage — prevents quota burn on transient DB errors. Applied to both open joins and request-to-join submissions.
- **AddChildren**: stop wiping existing children before insert. Snapshot, insert, then delete old rows on success — eliminates permanent data loss on insert failure.

## Test plan
- [x] vitest: 100/100 passing
- [ ] Host's own group shows correct member count on My Groups
- [ ] Joining an open group with insert error does not consume the monthly free request
- [ ] AddChildren with simulated insert error preserves existing rows