### PR TITLE
Parent audit batch 6: empty-reviews + realtime race

### DIFF
--- a/frontend/src/components/playgroup/RatingBreakdown.jsx
+++ b/frontend/src/components/playgroup/RatingBreakdown.jsx
@@ -20,6 +20,20 @@ function RatingBar({ label, value, max = 5 }) {
 export default function RatingBreakdown({ ratings }) {
   if (!ratings) return null;
 
+  // Brand-new groups have no reviews yet. Showing "0.0" with empty
+  // bars reads as "rated zero out of five" rather than "unrated", so
+  // render a neutral placeholder instead.
+  if (!ratings.count) {
+    return (
+      <div className="bg-cream-dark/30 border border-cream-dark rounded-2xl px-4 py-5 text-center">
+        <p className="text-sm font-medium text-charcoal">No reviews yet</p>
+        <p className="text-xs text-taupe mt-0.5">
+          Be the first to share your experience after a session.
+        </p>
+      </div>
+    );
+  }
+
   const overall =
     (ratings.environment +
       ratings.organization +

--- a/frontend/src/hooks/useGroupMessages.js
+++ b/frontend/src/hooks/useGroupMessages.js
@@ -54,36 +54,31 @@ export default function useGroupMessages(playgroupId, userId) {
           filter: `playgroup_id=eq.${playgroupId}`,
         },
         async (payload) => {
-          // Don't duplicate if we sent it ourselves (optimistic update)
+          // Side effects (the profile fetch) must not live inside a
+          // setState updater — React 18 strict mode runs updaters
+          // twice, so the fetch would fire twice per inbound message.
+          // Instead: fetch the profile once, then setMessages once
+          // with both the row and the profile attached.
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("first_name, last_name, photo_url")
+            .eq("id", payload.new.sender_id)
+            .single();
+
           setMessages((prev) => {
-            if (prev.find((m) => m.id === payload.new.id)) return prev;
-
-            // Fetch sender profile
-            supabase
-              .from("profiles")
-              .select("first_name, last_name, photo_url")
-              .eq("id", payload.new.sender_id)
-              .single()
-              .then(({ data: profile }) => {
-                setMessages((prev2) => {
-                  // Check again for duplicates
-                  const existing = prev2.find((m) => m.id === payload.new.id);
-                  if (existing) {
-                    // Update with profile info if missing
-                    if (!existing.profiles) {
-                      return prev2.map((m) =>
-                        m.id === payload.new.id
-                          ? { ...m, profiles: profile }
-                          : m
-                      );
-                    }
-                    return prev2;
-                  }
-                  return [...prev2, { ...payload.new, profiles: profile }];
-                });
-              });
-
-            return [...prev, { ...payload.new, profiles: null }];
+            // Don't duplicate if we sent it ourselves (optimistic
+            // update already added the row) — instead, backfill the
+            // profile if the optimistic row didn't have one.
+            const existing = prev.find((m) => m.id === payload.new.id);
+            if (existing) {
+              if (!existing.profiles && profile) {
+                return prev.map((m) =>
+                  m.id === payload.new.id ? { ...m, profiles: profile } : m
+                );
+              }
+              return prev;
+            }
+            return [...prev, { ...payload.new, profiles: profile }];
           });
         }
       )


### PR DESCRIPTION
## Summary
- **RatingBreakdown**: render a neutral "No reviews yet" placeholder when count is 0, instead of "0.0" with empty bars (which read as a 0/5 rating).
- **useGroupMessages**: move the sender-profile fetch out of the setState updater — strict-mode double-invocation was firing the supabase request twice per inbound message.

## Test plan
- [x] vitest: 100/100 passing
- [ ] Open a brand-new playgroup detail; reviews block shows the placeholder, not "0.0"
- [ ] Send a message in a chat; verify only one profiles request in network tab