### PR TITLE
Don't open own profile sheet from Members list

### DIFF
--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -593,11 +593,15 @@ export default function PlaygroupDetail() {
               })
               .map((m) => {
                 const isOrganizer = m.membership_role === "creator";
+                const isSelf = user?.id === m.id;
                 return (
                   <button
                     key={m.id}
-                    onClick={() => setActiveProfile(m)}
-                    className="bg-white rounded-xl border border-cream-dark p-3 flex gap-3 items-center text-left cursor-pointer"
+                    onClick={isSelf ? undefined : () => setActiveProfile(m)}
+                    disabled={isSelf}
+                    className={`bg-white rounded-xl border border-cream-dark p-3 flex gap-3 items-center text-left ${
+                      isSelf ? "cursor-default" : "cursor-pointer"
+                    }`}
                   >
                     <div
                       className={`w-10 h-10 rounded-full bg-sage-light flex-shrink-0 flex items-center justify-center overflow-hidden ${


### PR DESCRIPTION
## Summary
- In PlaygroupDetail Members list, the current user's own row no longer opens ProfilePanel
- Disables the button + drops cursor-pointer styling so tapping yourself is inert
- Member count and ordering unchanged

## Test plan
- [ ] Open a playgroup you're a member of → your own row is visible but not clickable
- [ ] Tap any other member's row → ProfilePanel opens as before