### PR TITLE
Reset Browse isHost when no creator memberships remain

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -49,7 +49,7 @@ export default function Browse() {
       .eq("role", "creator")
       .limit(1)
       .then(({ data }) => {
-        if (data?.length > 0) setIsHost(true);
+        setIsHost((data?.length || 0) > 0);
       });
   }, [user]);
 


### PR DESCRIPTION
## Summary
- Browse.jsx host check now sets isHost from the actual count instead of only flipping to true
- Fixes stale "(Organizer)" greeting and hidden "Host your own group?" CTA after a host deletes their last group

## Test plan
- [ ] As an organizer with one group: greeting shows "(Organizer)", "Host your own group?" CTA hidden
- [ ] Delete the only group, return to Browse → greeting drops "(Organizer)", CTA reappears
- [ ] Parent account with no creator memberships: unchanged behavior