### PR TITLE
Show mobile-first hint banner on desktop layouts

### DIFF
--- a/frontend/src/layouts/OrganizerLayout.jsx
+++ b/frontend/src/layouts/OrganizerLayout.jsx
@@ -10,6 +10,9 @@ import TabBar from "../components/layout/TabBar";
 export default function OrganizerLayout({ children }) {
   return (
     <div className="min-h-screen bg-[#F9F4ED] flex flex-col" data-mode="organizer">
+      <div className="hidden md:block bg-terracotta-light/40 text-center py-2 text-xs text-terracotta border-b border-cream-dark">
+        Kiddaboo is designed for mobile — open this on your phone for the best experience.
+      </div>
       <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
         <div className="px-5 pt-3">
           <span className="text-[10px] font-bold tracking-[1.5px] text-terracotta uppercase">

--- a/frontend/src/layouts/ParentLayout.jsx
+++ b/frontend/src/layouts/ParentLayout.jsx
@@ -12,6 +12,9 @@ import TabBar from "../components/layout/TabBar";
 export default function ParentLayout({ children }) {
   return (
     <div className="min-h-screen bg-cream flex flex-col" data-mode="parent">
+      <div className="hidden md:block bg-sage-light/40 text-center py-2 text-xs text-sage-dark border-b border-cream-dark">
+        Kiddaboo is designed for mobile — open this on your phone for the best experience.
+      </div>
       <div className="max-w-md mx-auto w-full flex-1 flex flex-col">
         <div className="px-5 pt-3">
           <span className="text-[10px] font-bold tracking-[1.5px] text-sage-dark uppercase">


### PR DESCRIPTION
## Summary
- Add a slim "designed for mobile" banner visible only at md+ breakpoints in both ParentLayout and OrganizerLayout
- Sets expectations for desktop visitors that the narrow phone-width column is intentional
- Sage tint on parent, terracotta tint on organizer to match the existing mode accents

## Test plan
- [ ] Resize browser past md breakpoint on /browse → banner appears at top
- [ ] Below md → banner is hidden
- [ ] Banner color matches the mode (sage for parent, terracotta for organizer)