### PR TITLE
Hide host CTAs from parent-account users

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -19,7 +19,7 @@ export default function Browse() {
   // #50: per-route document title
   useDocumentTitle("Browse");
   const navigate = useNavigate();
-  const { user, profile } = useAuth();
+  const { user, profile, accountType } = useAuth();
   const [isHost, setIsHost] = useState(false);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -434,8 +434,11 @@ export default function Browse() {
               ))}
             </div>
 
-            {/* Host CTA — hide for users who are already hosts */}
-            {!search && activeFilterCount === 0 && !isHost && (
+            {/* Host CTA — hide for users who are already hosts and for
+                parent-account users (parent flow stays focused on
+                browsing/joining; becoming a host requires re-onboarding
+                as organizer). */}
+            {!search && activeFilterCount === 0 && !isHost && accountType !== "parent" && (
               <div className="mt-12 relative overflow-hidden rounded-2xl bg-sage-light/15 p-8 md:p-12 flex flex-col md:flex-row items-center gap-8 group">
                 <div className="relative z-10 md:w-3/5">
                   <h2 className="text-2xl md:text-3xl font-heading font-bold text-sage-dark mb-3 leading-tight">
@@ -497,14 +500,18 @@ export default function Browse() {
                   No playgroups yet
                 </h3>
                 <p className="text-sm text-taupe mb-4">
-                  Be the first to create one in your area!
+                  {accountType === "parent"
+                    ? "Check back soon — new playgroups are added often."
+                    : "Be the first to create one in your area!"}
                 </p>
-                <button
-                  onClick={() => navigate("/host/create")}
-                  className="bg-sage text-white font-medium text-sm rounded-2xl px-6 py-3 cursor-pointer border-none hover:bg-sage-dark transition-colors"
-                >
-                  Organize a Playgroup
-                </button>
+                {accountType !== "parent" && (
+                  <button
+                    onClick={() => navigate("/host/create")}
+                    className="bg-sage text-white font-medium text-sm rounded-2xl px-6 py-3 cursor-pointer border-none hover:bg-sage-dark transition-colors"
+                  >
+                    Organize a Playgroup
+                  </button>
+                )}
               </>
             )}
           </div>

--- a/frontend/src/pages/MyGroups.jsx
+++ b/frontend/src/pages/MyGroups.jsx
@@ -41,7 +41,7 @@ const STATUS_BADGES = {
 export default function MyGroups() {
   useDocumentTitle("My Groups");
   const navigate = useNavigate();
-  const { user, loading: authLoading } = useAuth();
+  const { user, accountType, loading: authLoading } = useAuth();
 
   const [hosting, setHosting] = useState(null);
   const [joined, setJoined] = useState([]);
@@ -166,6 +166,10 @@ export default function MyGroups() {
       <div className="max-w-md mx-auto px-5 py-5 flex flex-col gap-6 w-full flex-1">
 
         {/* ───────── HOSTING SECTION ───────── */}
+        {/* Parent-account users don't see the Hosting section. The
+            parent flow stays focused on browsing/joining; becoming a
+            host requires re-onboarding as organizer. */}
+        {accountType !== "parent" && (
         <section>
           <div className="flex items-center gap-2 mb-3">
             <div className="w-6 h-6 rounded-full bg-sage/15 flex items-center justify-center">
@@ -267,9 +271,10 @@ export default function MyGroups() {
             </div>
           )}
         </section>
+        )}
 
         {/* ───────── DIVIDER ───────── */}
-        <div className="h-px bg-cream-dark" />
+        {accountType !== "parent" && <div className="h-px bg-cream-dark" />}
 
         {/* ───────── JOINED SECTION ───────── */}
         <section className="flex-1 flex flex-col">


### PR DESCRIPTION
## Summary
- Browse and MyGroups no longer surface "Become a Host" / "Organize a Playgroup" CTAs to parent-account users
- Parent flow now stays focused on browse + join; becoming a host requires re-onboarding as organizer
- Empty-state copy on Browse switched to a parent-friendly message ("Check back soon — new playgroups are added often") in place of the host nudge

## Test plan
- [ ] As parent: /browse with no results → no "Organize a Playgroup" button
- [ ] As parent: /browse with results → no "Share Your Space" hero card
- [ ] As parent: /my-groups → Hosting section and its divider hidden
- [ ] As organizer: all host CTAs and the Hosting section continue to render