### PR TITLE
Show join status on Browse playgroup cards

### DIFF
--- a/frontend/src/components/browse/PlaygroupCard.jsx
+++ b/frontend/src/components/browse/PlaygroupCard.jsx
@@ -118,15 +118,29 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
                   <span className="text-sm font-bold text-charcoal">{group.rating}</span>
                 </div>
               </div>
-              <div className={`w-full text-center py-3 rounded-xl text-sm font-bold transition-colors ${
-                spotsLeft > 0
-                  ? "bg-sage text-white group-hover:bg-sage-dark"
-                  : "bg-cream-dark text-taupe"
-              }`}>
-                {spotsLeft > 0
-                  ? group.accessType === "open" ? "Join Group" : "Request to Join"
-                  : "Waitlist"}
-              </div>
+              {group.joinStatus === "member" || group.joinStatus === "creator" ? (
+                <div className="w-full text-center py-3 rounded-xl text-sm font-bold bg-sage-light text-sage-dark">
+                  Joined
+                </div>
+              ) : group.joinStatus === "pending" ? (
+                <div className="w-full text-center py-3 rounded-xl text-sm font-bold bg-cream-dark text-taupe">
+                  Request Pending
+                </div>
+              ) : group.joinStatus === "waitlisted" ? (
+                <div className="w-full text-center py-3 rounded-xl text-sm font-bold bg-cream-dark text-taupe">
+                  On Waitlist
+                </div>
+              ) : (
+                <div className={`w-full text-center py-3 rounded-xl text-sm font-bold transition-colors ${
+                  spotsLeft > 0
+                    ? "bg-sage text-white group-hover:bg-sage-dark"
+                    : "bg-cream-dark text-taupe"
+                }`}>
+                  {spotsLeft > 0
+                    ? group.accessType === "open" ? "Join Group" : "Request to Join"
+                    : "Waitlist"}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -238,6 +252,18 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
         {group.isOwnGroup ? (
           <div className="w-full text-center py-2.5 rounded-xl text-sm font-bold bg-cream-dark text-taupe">
             Your Group
+          </div>
+        ) : group.joinStatus === "member" || group.joinStatus === "creator" ? (
+          <div className="w-full text-center py-2.5 rounded-xl text-sm font-bold bg-sage-light text-sage-dark">
+            Joined
+          </div>
+        ) : group.joinStatus === "pending" ? (
+          <div className="w-full text-center py-2.5 rounded-xl text-sm font-bold bg-cream-dark text-taupe">
+            Request Pending
+          </div>
+        ) : group.joinStatus === "waitlisted" ? (
+          <div className="w-full text-center py-2.5 rounded-xl text-sm font-bold bg-cream-dark text-taupe">
+            On Waitlist
           </div>
         ) : (
           <div className={`w-full text-center py-2.5 rounded-xl text-sm font-bold transition-colors ${

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -69,8 +69,11 @@ export default function Browse() {
     const fetchPlaygroups = async () => {
       setFetchError(false);
       setLoadingReal(true);
-      // Fetch playgroups and premium host IDs in parallel
-      const [pgResult, premiumResult] = await Promise.all([
+      // Fetch playgroups, premium host IDs, and the current user's
+      // own memberships in parallel. The membership map lets us surface
+      // join status on each card so we don't show "Join Group" to
+      // someone who's already a member.
+      const [pgResult, premiumResult, myMembershipsResult] = await Promise.all([
         supabase
           .from("playgroups")
           .select(`
@@ -86,10 +89,20 @@ export default function Browse() {
           .eq("type", "host_premium")
           .eq("status", "active")
           .gt("current_period_end", new Date().toISOString()),
+        user
+          ? supabase
+              .from("memberships")
+              .select("playgroup_id, role")
+              .eq("user_id", user.id)
+          : Promise.resolve({ data: [] }),
       ]);
 
       const premiumHostIds = new Set(
         (premiumResult.data || []).map((s) => s.user_id)
+      );
+
+      const myJoinStatusByPg = new Map(
+        (myMembershipsResult.data || []).map((m) => [m.playgroup_id, m.role])
       );
 
       if (pgResult.error) {
@@ -100,6 +113,7 @@ export default function Browse() {
           pgResult.data.map((pg, i) => ({
             ...transformPlaygroup(pg, i),
             isHostPremium: premiumHostIds.has(pg.creator_id),
+            joinStatus: myJoinStatusByPg.get(pg.id) || null,
           }))
         );
       }


### PR DESCRIPTION
## Summary
- Browse now fetches the current user's memberships alongside the playgroup listing and threads a per-card joinStatus through the cards
- PlaygroupCard renders mode-aware CTAs: "Joined" / "Request Pending" / "On Waitlist" / fallback to existing Join/Request to Join/Waitlist
- Both the standard and featured-card variants got the same treatment

## Test plan
- [ ] As a member of a group: card shows "Joined" instead of "Join Group"
- [ ] With a pending request: card shows "Request Pending"
- [ ] On a waitlist: card shows "On Waitlist"
- [ ] Non-member, open group: still shows "Join Group"
- [ ] Non-member, request-only group: still shows "Request to Join"
- [ ] Logged out: cards show the default join CTA (no errors from missing user)