### PR TITLE
Hotfix: revert TabBar to badges-prop (duplicate channel crash)

### DIFF
--- a/frontend/src/components/layout/TabBar.jsx
+++ b/frontend/src/components/layout/TabBar.jsx
@@ -1,6 +1,5 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
-import useNotifications from "../../hooks/useNotifications";
 
 // Icons
 const BrowseIcon = (active) => (
@@ -185,16 +184,11 @@ const ORGANIZER_TABS = [
   { path: "/my-profile", label: "Profile", icon: ProfileIcon },
 ];
 
-export default function TabBar() {
+export default function TabBar({ badges = {} }) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, signOut, accountType } = useAuth();
-  const { unreadMessages, pendingRequests } = useNotifications(user?.id);
+  const { signOut, accountType } = useAuth();
   const TABS = accountType === "organizer" ? ORGANIZER_TABS : PARENT_TABS;
-  const badges = {
-    "/messages": unreadMessages,
-    "/host/dashboard": pendingRequests,
-  };
 
   return (
     <nav aria-label="Main navigation" className="sticky bottom-0 z-30 bg-white border-t border-cream-dark shadow-[0_-2px_8px_rgba(0,0,0,0.04)] pb-[env(safe-area-inset-bottom)]">


### PR DESCRIPTION
## Summary
- #105 made TabBar call \`useNotifications\` directly, but AppLayout already does — duplicate Supabase channel \"notifications\" subscriptions crashed every authed page
- Revert to the prop-accepting signature; AppLayout's existing wiring covers it

## Test plan
- [ ] Load /messages while signed in — no error boundary
- [ ] Badge on Messages tab still updates on new messages