### PR TITLE
Show reviewer avatars in ReviewCard

### DIFF
--- a/frontend/src/components/playgroup/ReviewCard.jsx
+++ b/frontend/src/components/playgroup/ReviewCard.jsx
@@ -4,6 +4,7 @@ export default function ReviewCard({ review, isOwn, onEdit, onReport }) {
   // Support both old shape (mock) and new shape (real)
   const name = review.reviewer_name || review.reviewer || "User";
   const initials = review.reviewer_initials || review.initials || "U";
+  const avatarUrl = review.reviewer_avatar_url || review.avatar_url || null;
   const overall = review.rating_environment
     ? Math.round(
         (review.rating_environment +
@@ -26,9 +27,17 @@ export default function ReviewCard({ review, isOwn, onEdit, onReport }) {
     <div className="bg-white rounded-2xl p-4 border border-cream-dark">
       <div className="flex items-center gap-3 mb-3">
         {/* Avatar */}
-        <div className="w-9 h-9 rounded-full bg-terracotta-light flex items-center justify-center flex-shrink-0">
-          <span className="text-terracotta text-xs font-bold">{initials}</span>
-        </div>
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={name}
+            className="w-9 h-9 rounded-full object-cover flex-shrink-0"
+          />
+        ) : (
+          <div className="w-9 h-9 rounded-full bg-terracotta-light flex items-center justify-center flex-shrink-0">
+            <span className="text-terracotta text-xs font-bold">{initials}</span>
+          </div>
+        )}
 
         {/* Name + date */}
         <div className="flex-1">

--- a/frontend/src/hooks/useReviews.js
+++ b/frontend/src/hooks/useReviews.js
@@ -14,7 +14,7 @@ export default function useReviews(playgroupId) {
       .from("reviews")
       .select(`
         *,
-        profiles:reviewer_id ( first_name, last_name )
+        profiles:reviewer_id ( first_name, last_name, avatar_url )
       `)
       .eq("playgroup_id", playgroupId)
       .order("created_at", { ascending: false });
@@ -29,6 +29,7 @@ export default function useReviews(playgroupId) {
             reviewer_name: `${first} ${last}`.trim(),
             reviewer_initials:
               (first[0] || "U").toUpperCase() + (last[0] || "").toUpperCase(),
+            reviewer_avatar_url: r.profiles?.avatar_url || null,
           };
         })
       );
@@ -143,7 +144,7 @@ export default function useReviews(playgroupId) {
         })
         .select(`
           *,
-          profiles:reviewer_id ( first_name, last_name )
+          profiles:reviewer_id ( first_name, last_name, avatar_url )
         `)
         .single();
 
@@ -155,6 +156,7 @@ export default function useReviews(playgroupId) {
           reviewer_name: `${first} ${last}`.trim(),
           reviewer_initials:
             (first[0] || "U").toUpperCase() + (last[0] || "").toUpperCase(),
+          reviewer_avatar_url: data.profiles?.avatar_url || null,
         };
         setReviews((prev) => [enriched, ...prev]);
       }


### PR DESCRIPTION
## Summary
- useReviews didn't pull \`avatar_url\` from profiles, so even parents with photos showed initials
- Add \`avatar_url\` to the select, thread through as \`reviewer_avatar_url\`, render \`<img>\` with initials fallback

## Test plan
- [ ] Host dashboard → Reviews section shows parent profile photos
- [ ] Parents without an uploaded photo still show initials