### PR TITLE
Make verify-otp errors readable by the client

### DIFF
--- a/supabase/functions/verify-otp/index.ts
+++ b/supabase/functions/verify-otp/index.ts
@@ -81,16 +81,20 @@ serve(async (req) => {
     // 404 means there's no verification record on Twilio's side — either
     // expired, already consumed, or never started. Treat as "no active
     // challenge" so the UI can prompt a resend.
+    //
+    // supabase-js swallows non-2xx response bodies, so user-actionable
+    // errors must come back as 200 + {ok:false, error} to be readable
+    // by the client (matching send-otp's pattern).
     if (result.status === 404) {
-      return json({ error: "no_active_challenge" }, 410);
+      return json({ ok: false, error: "no_active_challenge" });
     }
     console.error("twilio verify check failed:", result.status, result.body);
-    return json({ error: "verify_failed", detail: result.body }, 502);
+    return json({ ok: false, error: "verify_failed", detail: result.body });
   }
 
   const status = (result.body as { status?: string })?.status;
   if (status !== "approved") {
-    return json({ error: "code_mismatch" }, 400);
+    return json({ ok: false, error: "code_mismatch" });
   }
 
   const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- verify-otp returned non-2xx for code_mismatch/no_active_challenge/verify_failed; supabase-js swallows those bodies, so the UI showed generic \"Something went wrong\" copy
- Switch to 200 + \`{ok:false, error}\` (matching send-otp + phone_in_use)
- True server errors still 500

## Test plan
- [ ] Enter wrong OTP → see \"Code doesn't match. Try again.\"
- [ ] Wait past expiry, enter old code → see \"That code expired. Tap Resend...\"
- [ ] Enter correct code → still verifies and proceeds

## Deploy note
- After merge, redeploy: \`supabase functions deploy verify-otp\`