### PR TITLE
Premium: priority in host queues + drop stale map claim

### DIFF
--- a/frontend/src/components/host/RequestCard.jsx
+++ b/frontend/src/components/host/RequestCard.jsx
@@ -59,6 +59,11 @@ export default function RequestCard({
             <p className="text-sm font-medium text-charcoal">
               {request.name}
             </p>
+            {request.isPremium && !actionState && (
+              <span className="text-[10px] bg-sage text-white px-1.5 py-0.5 rounded-full font-medium">
+                Premium
+              </span>
+            )}
             {actionState && (
               <span
                 className={`text-[10px] ${actionState.textColor} font-medium flex items-center gap-0.5`}

--- a/frontend/src/pages/Premium.jsx
+++ b/frontend/src/pages/Premium.jsx
@@ -28,7 +28,6 @@ const PLANS = [
 const FEATURES = [
   { free: "1 join request / month", premium: "Unlimited join requests" },
   { free: "Browse & search playgroups", premium: "Browse & search playgroups", both: true },
-  { free: "Near Me map view", premium: "Near Me map view", both: true },
   { free: "Basic filters", premium: "Advanced filters (age, philosophy)" },
   { free: "Group chat", premium: "Group chat", both: true },
   { free: "—", premium: "Priority in host queues" },

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -90,6 +90,24 @@ export default function HostDashboard() {
           childrenByUser[c.user_id].push(c);
         });
 
+        // Premium parents float to the top of the pending queue. Fetch
+        // active joiner subscriptions for the pending users so we can
+        // tag and sort below.
+        const pendingUserIds = memberships
+          .filter((m) => m.role === "pending")
+          .map((m) => m.user_id);
+        let premiumPendingIds = new Set();
+        if (pendingUserIds.length > 0) {
+          const { data: pendingSubs } = await supabase
+            .from("subscriptions")
+            .select("user_id")
+            .eq("type", "joiner")
+            .eq("status", "active")
+            .gt("current_period_end", new Date().toISOString())
+            .in("user_id", pendingUserIds);
+          premiumPendingIds = new Set((pendingSubs || []).map((s) => s.user_id));
+        }
+
         // Split into pending requests and active members
         const pending = memberships
           .filter((m) => m.role === "pending")
@@ -117,7 +135,16 @@ export default function HostDashboard() {
               bio: m.profiles?.bio || "",
               answers,
               requestedAt: timeAgo(m.created_at),
+              createdAt: m.created_at,
+              isPremium: premiumPendingIds.has(m.user_id),
             };
+          })
+          // Premium first; within each tier, newest first (matches the
+          // existing `.order("created_at", { ascending: false })` on
+          // memberships).
+          .sort((a, b) => {
+            if (a.isPremium !== b.isPremium) return a.isPremium ? -1 : 1;
+            return b.createdAt.localeCompare(a.createdAt);
           });
 
         const active = memberships


### PR DESCRIPTION
## Summary
First of three PRs delivering the unwired Premium claims (audit found 3 of 8 claims weren't backed by code).

- Drop \`Near Me map view\` from FEATURES — map was removed in 4ff661b
- Tag pending join requests with isPremium based on active joiner subscriptions
- Sort premium parents to the top of the host pending queue (newest-first within each tier)
- Show \"Premium\" chip on the request card

## Test plan
- [ ] Premium page no longer shows \"Near Me map view\" row
- [ ] As a host with both free and premium parents pending, premium ones appear first
- [ ] Premium chip visible on premium requesters' cards; suppressed after approve/decline

## Follow-ups
- PR 2: Early access to new groups (24h gate)
- PR 3: Advanced filters gating