### PR TITLE
Premium: fix filter claim copy (age, setting)

### DIFF
--- a/frontend/src/pages/Premium.jsx
+++ b/frontend/src/pages/Premium.jsx
@@ -28,7 +28,7 @@ const PLANS = [
 const FEATURES = [
   { free: "1 join request / month", premium: "Unlimited join requests" },
   { free: "Browse & search playgroups", premium: "Browse & search playgroups", both: true },
-  { free: "Basic filters", premium: "Advanced filters (age, philosophy)" },
+  { free: "Basic filters", premium: "Advanced filters (age, setting)" },
   { free: "Group chat", premium: "Group chat", both: true },
   { free: "—", premium: "Priority in host queues" },
   { free: "—", premium: "Premium badge on profile" },


### PR DESCRIPTION
## Summary
- Premium feature row now reads "Advanced filters (age, setting)" — matches what we actually gate

## Test plan
- [ ] /premium feature table shows the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)