### PR TITLE
Premium: chip next to greeting on Browse

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -269,9 +269,19 @@ export default function Browse() {
                 Kiddaboo
               </h1>
               {profile?.first_name && (
-                <span className="text-sm font-medium text-taupe truncate">
-                  Hi, {profile.first_name}{isHost ? " (Organizer)" : ""}
-                </span>
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm font-medium text-taupe truncate">
+                    Hi, {profile.first_name}{isHost ? " (Organizer)" : ""}
+                  </span>
+                  {isPremium && (
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-white bg-amber-400 px-1.5 py-0.5 rounded-full shrink-0">
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                      </svg>
+                      Premium
+                    </span>
+                  )}
+                </div>
               )}
             </div>
             {profile && (


### PR DESCRIPTION
## Summary
- Premium parents see a gold "★ Premium" chip beside the greeting on /browse

## Test plan
- [ ] Free account: no chip
- [ ] Premium account (e.g. Pathma): chip visible next to "Hi, X"

🤖 Generated with [Claude Code](https://claude.com/claude-code)