### PR TITLE
Security: lock down quota RLS + atomic claim (PR-D)

### DIFF
--- a/supabase/functions/submit-join-request/index.ts
+++ b/supabase/functions/submit-join-request/index.ts
@@ -113,19 +113,31 @@ serve(async (req) => {
     .gt("current_period_end", now);
   const isPremium = (subs || []).length > 0;
 
-  // 5. Free-tier monthly quota.
+  // 5. Free-tier monthly quota — atomic claim.
+  //    claim_join_request_quota() runs an INSERT … ON CONFLICT …
+  //    RETURNING in a single statement. Two concurrent calls cannot
+  //    both succeed past the cap (closes the prior read-modify-write
+  //    race). Returns the new count if the claim succeeded, NULL if
+  //    the user has hit the limit.
   const month = now.slice(0, 7); // YYYY-MM
+  let claimed = false;
   if (!isPremium) {
-    const { data: usage } = await admin
-      .from("join_request_usage")
-      .select("request_count")
-      .eq("user_id", userId)
-      .eq("month", month)
-      .maybeSingle();
-    const used = usage?.request_count || 0;
-    if (used >= FREE_JOIN_LIMIT) {
-      return json({ ok: false, error: "quota_exceeded", used, limit: FREE_JOIN_LIMIT });
+    const { data: claimResult, error: claimErr } = await admin.rpc(
+      "claim_join_request_quota",
+      { p_user_id: userId, p_month: month, p_limit: FREE_JOIN_LIMIT },
+    );
+    if (claimErr) {
+      console.error("claim_join_request_quota failed:", claimErr);
+      return json({ ok: false, error: "quota_check_failed" });
     }
+    if (claimResult === null || claimResult === undefined) {
+      return json({
+        ok: false,
+        error: "quota_exceeded",
+        limit: FREE_JOIN_LIMIT,
+      });
+    }
+    claimed = true;
   }
 
   // 6. Insert membership.
@@ -145,25 +157,19 @@ serve(async (req) => {
   const { error: insertErr } = await admin.from("memberships").insert(insertRow);
   if (insertErr) {
     console.error("membership insert failed:", insertErr);
+    // Roll back the quota claim so a transient DB error doesn't burn
+    // the user's monthly request. Best-effort — if this decrement also
+    // fails, we'd rather under-charge than fail the response twice.
+    if (claimed) {
+      await admin
+        .from("join_request_usage")
+        .update({ request_count: 0 })
+        .eq("user_id", userId)
+        .eq("month", month)
+        .gt("request_count", 0)
+        .lte("request_count", 1);
+    }
     return json({ ok: false, error: "insert_failed", detail: insertErr.message });
-  }
-
-  // 7. Increment usage only for free users and only after successful
-  //    insert, so a failed write doesn't burn the user's quota.
-  if (!isPremium) {
-    const { data: usage } = await admin
-      .from("join_request_usage")
-      .select("request_count")
-      .eq("user_id", userId)
-      .eq("month", month)
-      .maybeSingle();
-    const next = (usage?.request_count || 0) + 1;
-    await admin
-      .from("join_request_usage")
-      .upsert(
-        { user_id: userId, month, request_count: next },
-        { onConflict: "user_id,month" },
-      );
   }
 
   return json({ ok: true, role });

--- a/supabase/migrations/20260425000002_lockdown_quota_rls.sql
+++ b/supabase/migrations/20260425000002_lockdown_quota_rls.sql
@@ -1,0 +1,60 @@
+-- Lock down RLS so the free-tier join quota can't be bypassed.
+--
+-- Before this migration:
+--   * memberships had a public INSERT policy keyed on auth.uid() = user_id,
+--     so any authenticated user could open devtools and insert a membership
+--     row directly, bypassing submit-join-request and its quota check.
+--   * join_request_usage had INSERT and UPDATE policies on auth.uid() = user_id,
+--     so a user could reset their own request_count back to 0.
+--
+-- After: both tables are written exclusively by service-role code paths
+-- (submit-join-request and the host-side approve/decline flows on
+-- memberships, which run through their own edge functions or the
+-- creator-update policy). RLS still permits SELECT for the user's own
+-- data on join_request_usage.
+--
+-- Also adds claim_join_request_quota() — an atomic
+-- INSERT … ON CONFLICT … RETURNING that closes the read-modify-write
+-- TOCTOU race in submit-join-request. Concurrent requests from the
+-- same free user can no longer both pass the "used=0" check.
+
+-- 1. Drop client INSERT on memberships. submit-join-request runs as
+--    service role and bypasses RLS; that's the only legitimate path
+--    for creating a membership row from the parent side.
+DROP POLICY IF EXISTS "Users can request to join" ON memberships;
+
+-- 2. Drop client INSERT/UPDATE on join_request_usage. Only the edge
+--    function (service role) writes here.
+DROP POLICY IF EXISTS "Users can upsert own usage" ON join_request_usage;
+DROP POLICY IF EXISTS "Users can update own usage" ON join_request_usage;
+
+-- 3. Atomic claim. Returns the new count if the user is still under
+--    the limit, NULL if they've hit it. Single statement, single
+--    row lock — two concurrent calls cannot both succeed past the cap.
+CREATE OR REPLACE FUNCTION claim_join_request_quota(
+  p_user_id uuid,
+  p_month text,
+  p_limit integer
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_count integer;
+BEGIN
+  INSERT INTO join_request_usage (user_id, month, request_count)
+  VALUES (p_user_id, p_month, 1)
+  ON CONFLICT (user_id, month) DO UPDATE
+    SET request_count = join_request_usage.request_count + 1
+    WHERE join_request_usage.request_count < p_limit
+  RETURNING request_count INTO new_count;
+
+  RETURN new_count;
+END;
+$$;
+
+-- Service role + authenticated callers only. The edge function uses
+-- service role; lock down the function from anon entirely.
+REVOKE ALL ON FUNCTION claim_join_request_quota(uuid, text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION claim_join_request_quota(uuid, text, integer) TO service_role;


### PR DESCRIPTION
## Summary
Closes three findings from the audit:
- **C1**: drops the public \`memberships\` INSERT policy. Clients can no longer bypass \`submit-join-request\` and skip the quota.
- **C2**: drops client INSERT/UPDATE on \`join_request_usage\`. Free users cannot reset their own \`request_count\`.
- **H4**: replaces read-modify-write with \`claim_join_request_quota()\` — an atomic INSERT … ON CONFLICT … RETURNING. Two concurrent join requests from the same user can't both pass the cap check.

## Deploy steps (in order)
1. **Apply migration** — Supabase Dashboard → SQL Editor, paste \`supabase/migrations/20260425000002_lockdown_quota_rls.sql\` and run.
2. **Deploy edge function**:
   \`\`\`
   cd ~/Kiddaboo && supabase functions deploy submit-join-request --project-ref pdgtryghvibhmmroqvdk
   \`\`\`

Order matters: if the function deploys before the migration, the RPC call fails and free users can't join anything. If the migration runs first, existing function still works against the unchanged table writes (just gracefully — old code path is no longer needed but doesn't break).

## Test plan
- [ ] As a free user with quota remaining, join one open group — should succeed
- [ ] Same free user attempts a second join in the same month — should fail with \`quota_exceeded\`
- [ ] Open devtools and try \`supabase.from('memberships').insert({user_id:..., playgroup_id:..., role:'member'})\` — should fail with RLS violation
- [ ] Open devtools and try \`supabase.from('join_request_usage').update({request_count:0}).eq('user_id', myId)\` — should fail with RLS violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)