### PR TITLE
Reminder dedupe + playgroups RLS hardening (PR-E)

### DIFF
--- a/supabase/functions/send-session-reminders/index.ts
+++ b/supabase/functions/send-session-reminders/index.ts
@@ -116,17 +116,36 @@ async function filterPremiumOnly(reminders: Reminder[]): Promise<Reminder[]> {
 }
 
 async function alreadySent(r: Reminder): Promise<boolean> {
-  // Insert-as-dedupe: relies on the unique index. If the row already
-  // exists we get a 23505 and skip; if it inserts, we own the send.
+  // Cheap pre-check before sending. Catches the steady-state case
+  // where a previous tick already marked this reminder sent.
+  const { data, error } = await admin
+    .from("session_reminders_sent")
+    .select("id")
+    .eq("session_id", r.session_id)
+    .eq("user_id", r.user_id)
+    .eq("kind", r.kind)
+    .maybeSingle();
+  if (error) {
+    console.error("dedupe check failed:", error);
+    return false; // fail open — better to retry than miss forever
+  }
+  return !!data;
+}
+
+async function markSent(r: Reminder): Promise<void> {
+  // Best-effort. If two cron ticks both passed the pre-check and both
+  // sent (rare), the second insert hits the unique index and 23505s —
+  // expected. The push itself uses tag=`session-reminder-${id}-${kind}`
+  // which the device's notification system uses to coalesce duplicates,
+  // so the user sees one notification regardless.
   const { error } = await admin.from("session_reminders_sent").insert({
     session_id: r.session_id,
     user_id: r.user_id,
     kind: r.kind,
   });
-  if (!error) return false;
-  if ((error as { code?: string }).code === "23505") return true;
-  console.error("dedupe insert failed:", error);
-  return true; // fail closed — better to skip than double-send
+  if (error && (error as { code?: string }).code !== "23505") {
+    console.error("mark-sent insert failed:", error);
+  }
 }
 
 async function sendReminder(r: Reminder): Promise<boolean> {
@@ -189,8 +208,12 @@ serve(async (_req) => {
       continue;
     }
     const ok = await sendReminder(r);
-    if (ok) sent++;
-    else failed++;
+    if (ok) {
+      await markSent(r);
+      sent++;
+    } else {
+      failed++;
+    }
   }
 
   return new Response(

--- a/supabase/migrations/20260425000003_playgroups_active_only.sql
+++ b/supabase/migrations/20260425000003_playgroups_active_only.sql
@@ -1,0 +1,31 @@
+-- Restrict client-side SELECT on playgroups to active rows.
+--
+-- Before: "Playgroups are viewable by everyone" used USING (true), so
+-- soft-deleted / archived playgroups (is_active = false) were still
+-- visible to any authenticated user. Hosts who deactivate a group
+-- expect it to disappear from search/browse for everyone except
+-- themselves; the previous policy didn't honor that.
+--
+-- After: clients see active playgroups, plus their own playgroups
+-- (so creators can still find inactive groups to reactivate or
+-- archive permanently), plus playgroups they're a member of (so a
+-- member who's RSVP'd to a session in a recently-deactivated group
+-- still sees it in their lists).
+--
+-- screening_questions remains readable on active rows because
+-- prospective members need to see the questions to answer when
+-- applying — that exposure is intentional.
+
+DROP POLICY IF EXISTS "Playgroups are viewable by everyone" ON playgroups;
+
+CREATE POLICY "Playgroups are viewable when active or owned"
+  ON playgroups FOR SELECT
+  USING (
+    is_active = true
+    OR creator_id = auth.uid()
+    OR auth.uid() IN (
+      SELECT user_id FROM memberships
+      WHERE playgroup_id = playgroups.id
+        AND role IN ('creator', 'member', 'pending')
+    )
+  );


### PR DESCRIPTION
## Summary
- **H1**: \`send-session-reminders\` now sends the push first and marks dedupe row only on success. Previously a transient send failure left a dedupe row that silently dropped the reminder forever. Rare double-sends are coalesced at the device level via the existing notification \`tag\`.
- **H10**: \`playgroups\` SELECT policy restricted to active rows. Inactive playgroups now visible only to their creator and existing members.

## Deploy steps
1. **Apply migration** — Supabase Dashboard → SQL Editor → run \`supabase/migrations/20260425000003_playgroups_active_only.sql\`
2. **Deploy edge function**:
   \`\`\`
   cd ~/Kiddaboo && supabase functions deploy send-session-reminders --project-ref pdgtryghvibhmmroqvdk
   \`\`\`

## Test plan
- [ ] Migration runs cleanly
- [ ] Edge function deploys
- [ ] Browse page still shows active playgroups
- [ ] Host's archived playgroup still appears in their host dashboard
- [ ] Curl invoke returns \`{candidates, premium, sent, skipped, failed}\` shape unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)