### PR TITLE
Capacity cap + TZ-aware reminders (PR-G)

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }) {
   const fetchProfile = async (userId) => {
     const { data, error } = await supabase
       .from("profiles")
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type, timezone")
       .eq("id", userId)
       .single();
 
@@ -52,6 +52,21 @@ export function AuthProvider({ children }) {
     }
     if (data) {
       setProfile(data);
+      // Sync the user's IANA timezone so server-side scheduled pushes
+      // (session reminders) can render times in their local TZ instead
+      // of the Deno edge runtime's UTC.
+      try {
+        const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (browserTz && browserTz !== data.timezone) {
+          supabase
+            .from("profiles")
+            .update({ timezone: browserTz })
+            .eq("id", userId)
+            .then(() => {});
+        }
+      } catch {
+        // Intl support is universal in supported browsers; swallow if not.
+      }
     }
     setLoading(false);
   };

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -38,6 +38,8 @@ function joinErrorMessage(code) {
       return "You're already part of this group.";
     case "playgroup_inactive":
       return "This playgroup isn't accepting new members right now.";
+    case "playgroup_full":
+      return "This playgroup is full. Try another group or check back later.";
     case "playgroup_not_found":
       return "We couldn't find this playgroup.";
     default:

--- a/supabase/functions/send-session-reminders/index.ts
+++ b/supabase/functions/send-session-reminders/index.ts
@@ -34,6 +34,10 @@ type Reminder = {
   scheduled_at: string;
   playgroup_id: string;
   playgroup_name: string;
+  // IANA timezone synced from the user's browser. Defaults to "UTC"
+  // when missing so toLocaleString won't throw on the server side,
+  // though the rendered time will be off until the client syncs.
+  user_tz: string;
 };
 
 async function findDueReminders(kind: "24h" | "2h"): Promise<Reminder[]> {
@@ -81,6 +85,8 @@ async function findDueReminders(kind: "24h" | "2h"): Promise<Reminder[]> {
       scheduled_at: s.scheduled_at,
       playgroup_id: s.playgroup_id,
       playgroup_name: s.playgroups?.name || "your playgroup",
+      // Real value attached in filterPremiumOnly once we look up profiles.
+      user_tz: "UTC",
     };
   });
 }
@@ -99,20 +105,24 @@ async function filterPremiumOnly(reminders: Reminder[]): Promise<Reminder[]> {
 
   // Honor the per-user opt-out from NotificationSettings. Default
   // is on — only filter out users who explicitly set the toggle
-  // to false.
+  // to false. Also fetch each user's IANA timezone so we can format
+  // session times in their local TZ instead of UTC.
   const { data: profiles } = await admin
     .from("profiles")
-    .select("id, notification_prefs")
+    .select("id, notification_prefs, timezone")
     .in("id", userIds);
   const optedOut = new Set(
     (profiles || [])
       .filter((p) => p.notification_prefs?.session_reminders === false)
       .map((p) => p.id),
   );
-
-  return reminders.filter(
-    (r) => premiumIds.has(r.user_id) && !optedOut.has(r.user_id),
+  const tzByUser = new Map<string, string>(
+    (profiles || []).map((p) => [p.id as string, (p.timezone as string) || "UTC"]),
   );
+
+  return reminders
+    .filter((r) => premiumIds.has(r.user_id) && !optedOut.has(r.user_id))
+    .map((r) => ({ ...r, user_tz: tzByUser.get(r.user_id) || "UTC" }));
 }
 
 async function alreadySent(r: Reminder): Promise<boolean> {
@@ -150,15 +160,30 @@ async function markSent(r: Reminder): Promise<void> {
 
 async function sendReminder(r: Reminder): Promise<boolean> {
   const start = new Date(r.scheduled_at);
-  const timeStr = start.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  const dayStr = start.toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "short",
-    day: "numeric",
-  });
+  // Wrap in try/catch — an invalid TZ string from the DB would otherwise
+  // throw a RangeError. Fall back to UTC formatting in that case.
+  let timeStr: string;
+  let dayStr: string;
+  try {
+    timeStr = start.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: r.user_tz,
+    });
+    dayStr = start.toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "short",
+      day: "numeric",
+      timeZone: r.user_tz,
+    });
+  } catch {
+    timeStr = start.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    dayStr = start.toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "short",
+      day: "numeric",
+    });
+  }
 
   const title =
     r.kind === "24h"

--- a/supabase/functions/submit-join-request/index.ts
+++ b/supabase/functions/submit-join-request/index.ts
@@ -91,7 +91,23 @@ serve(async (req) => {
     return json({ ok: false, error: "playgroup_inactive" });
   }
 
-  // 3. Already-a-member guard.
+  // 3. Capacity guard for open-access groups. For request/invite groups
+  //    the host approves manually so the host owns capacity decisions;
+  //    for open groups the insert is auto-approved, so we have to
+  //    enforce max_families server-side or a popular open group can
+  //    blow past its cap during a brief click-race.
+  if (pg.access_type === "open" && pg.max_families) {
+    const { count: memberCount } = await admin
+      .from("memberships")
+      .select("id", { count: "exact", head: true })
+      .eq("playgroup_id", playgroupId)
+      .in("role", ["creator", "member"]);
+    if (memberCount !== null && memberCount >= pg.max_families) {
+      return json({ ok: false, error: "playgroup_full" });
+    }
+  }
+
+  // 4. Already-a-member guard.
   const { data: existing } = await admin
     .from("memberships")
     .select("id, role")

--- a/supabase/migrations/20260425000004_profile_timezone.sql
+++ b/supabase/migrations/20260425000004_profile_timezone.sql
@@ -1,0 +1,11 @@
+-- Store the user's IANA timezone so the reminder edge function can
+-- format session times correctly. Without this, send-session-reminders
+-- runs in the Deno edge runtime's TZ (UTC) and renders 5pm-local
+-- as "10:00 PM" to a Pacific-coast user.
+--
+-- Populated client-side via Intl.DateTimeFormat().resolvedOptions().timeZone
+-- on first authenticated load. Hosts and parents both get this column
+-- since both might receive scheduled push notifications in the future.
+
+alter table public.profiles
+  add column if not exists timezone text;


### PR DESCRIPTION
## Summary
- **H5**: \`submit-join-request\` enforces \`max_families\` for open-access groups. Previously a popular open group could blow past its cap in a click race.
- **M1**: \`send-session-reminders\` formats times in the user's local timezone instead of UTC. \`profiles\` gains a \`timezone\` column populated client-side from \`Intl.DateTimeFormat().resolvedOptions().timeZone\`.
- New error code \`playgroup_full\` surfaced in PlaygroupDetail's join error mapper.

## Deploy steps
1. **Apply migration**:
   \`\`\`sql
   alter table public.profiles add column if not exists timezone text;
   \`\`\`
2. **Deploy edge functions**:
   \`\`\`
   cd ~/Kiddaboo && supabase functions deploy submit-join-request --project-ref pdgtryghvibhmmroqvdk && supabase functions deploy send-session-reminders --project-ref pdgtryghvibhmmroqvdk
   \`\`\`

## Test plan
- [ ] Migration runs cleanly
- [ ] Both functions deploy
- [ ] Sign in once → check profiles row gets \`timezone\` populated (e.g. \`America/Los_Angeles\`)
- [ ] As a free user, try to join a full open group → expect \`playgroup_full\` error
- [ ] Curl the reminder function → still returns \`{candidates, premium, sent, skipped, failed}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)