### PR TITLE
Audit cleanup: parallel fetches, pagination, length caps, top-level guard

### DIFF
--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -235,7 +235,15 @@ serve(async (req: Request) => {
           month: "short",
           day: "numeric",
         });
-        const reason = (record.cancel_reason as string | null)?.trim();
+        // Cap the reason at ~150 chars so a host pasting an essay doesn't
+        // produce a multi-screen push body — most browsers truncate long
+        // notification bodies anyway, and we'd rather control the cut.
+        const REASON_MAX = 150;
+        const rawReason = (record.cancel_reason as string | null)?.trim();
+        const reason =
+          rawReason && rawReason.length > REASON_MAX
+            ? rawReason.slice(0, REASON_MAX - 1) + "…"
+            : rawReason;
         const body = reason
           ? `${dayStr} — ${reason}`
           : `${dayStr} session has been cancelled`;

--- a/supabase/functions/send-session-reminders/index.ts
+++ b/supabase/functions/send-session-reminders/index.ts
@@ -63,13 +63,26 @@ async function findDueReminders(kind: "24h" | "2h"): Promise<Reminder[]> {
   const sessionIds = sessions.map((s) => s.id);
   const sessionById = new Map(sessions.map((s) => [s.id, s]));
 
-  // RSVPs going for those sessions.
-  const { data: rsvps, error: rsvpErr } = await admin
-    .from("rsvps")
-    .select("session_id, user_id")
-    .in("session_id", sessionIds)
-    .eq("status", "going");
-  if (rsvpErr || !rsvps) return [];
+  // RSVPs going for those sessions. Paginate — supabase-js caps a single
+  // .select() at 1000 rows by default, and a viral session window can
+  // realistically blow past that across all due sessions combined.
+  const PAGE = 1000;
+  const rsvps: { session_id: string; user_id: string }[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error: rsvpErr } = await admin
+      .from("rsvps")
+      .select("session_id, user_id")
+      .in("session_id", sessionIds)
+      .eq("status", "going")
+      .range(from, from + PAGE - 1);
+    if (rsvpErr) {
+      console.error("findDueReminders rsvps query failed:", rsvpErr);
+      return [];
+    }
+    if (!data || data.length === 0) break;
+    rsvps.push(...(data as { session_id: string; user_id: string }[]));
+    if (data.length < PAGE) break;
+  }
 
   return rsvps.map((r) => {
     const s = sessionById.get(r.session_id) as {
@@ -218,37 +231,52 @@ async function sendReminder(r: Reminder): Promise<boolean> {
 }
 
 serve(async (_req) => {
-  const allReminders = [
-    ...(await findDueReminders("24h")),
-    ...(await findDueReminders("2h")),
-  ];
-  const premium = await filterPremiumOnly(allReminders);
+  try {
+    // The 24h and 2h windows are independent queries — fetch them in
+    // parallel so a slow round-trip on one doesn't push the other past
+    // the cron tick budget.
+    const [r24, r2] = await Promise.all([
+      findDueReminders("24h"),
+      findDueReminders("2h"),
+    ]);
+    const allReminders = [...r24, ...r2];
+    const premium = await filterPremiumOnly(allReminders);
 
-  let sent = 0;
-  let skipped = 0;
-  let failed = 0;
-  for (const r of premium) {
-    if (await alreadySent(r)) {
-      skipped++;
-      continue;
+    let sent = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const r of premium) {
+      if (await alreadySent(r)) {
+        skipped++;
+        continue;
+      }
+      const ok = await sendReminder(r);
+      if (ok) {
+        await markSent(r);
+        sent++;
+      } else {
+        failed++;
+      }
     }
-    const ok = await sendReminder(r);
-    if (ok) {
-      await markSent(r);
-      sent++;
-    } else {
-      failed++;
-    }
+
+    return new Response(
+      JSON.stringify({
+        candidates: allReminders.length,
+        premium: premium.length,
+        sent,
+        skipped,
+        failed,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    // Top-level guard so an unexpected throw (bad TZ string, network
+    // hiccup mid-loop, malformed row) doesn't 502 the cron — the next
+    // tick can recover the missed window since dedupe is per-(session,user,kind).
+    console.error("send-session-reminders top-level error:", err);
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
   }
-
-  return new Response(
-    JSON.stringify({
-      candidates: allReminders.length,
-      premium: premium.length,
-      sent,
-      skipped,
-      failed,
-    }),
-    { status: 200, headers: { "Content-Type": "application/json" } },
-  );
 });


### PR DESCRIPTION
## Summary
Bundle of small high-confidence cleanups from the post-Phase-1 audit:

- **M3** — `send-session-reminders`: fetch 24h and 2h windows in parallel via `Promise.all` instead of serially.
- **M11** — `send-session-reminders`: paginate the `rsvps` query in `findDueReminders`. Prior code relied on the supabase-js implicit 1000-row cap, which would silently drop reminders for popular session windows.
- **L5** — `send-session-reminders`: wrap the serve handler in try/catch so an unexpected throw doesn't 502 the cron. Dedupe is per-(session,user,kind) so the next tick recovers the window.
- **M12** — `send-push`: cap `cancel_reason` at 150 chars before splicing into the push body so a host pasting an essay can't blow up the notification.

No schema changes. Both edge functions need redeploy.

## Test plan
- [ ] Deploy `send-session-reminders` and `send-push`
- [ ] Trigger session-reminder cron tick — confirm it still emits and `{candidates,premium,sent,skipped,failed}` shape unchanged
- [ ] Cancel a session with a >150 char reason and confirm the push body is truncated cleanly with an ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)