### PR TITLE
Robust membership-transition pushes via dedupe table (H7+H8)

### DIFF
--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -99,8 +99,44 @@ serve(async (req: Request) => {
       const oldRole = old_record?.role;
       const newRole = record.role;
 
-      // Request approved → notify the requester
-      if (oldRole === "pending" && newRole === "member") {
+      // Tolerate missing old_record. The "Send old record" webhook
+      // toggle has to be on for oldRole to be populated; if someone
+      // forgets to flip it during a config change, the previous
+      // implementation silently never sent approval/decline pushes.
+      // We instead fall back to deciding by newRole alone, gated by
+      // a (membership_id, kind) dedupe claim so a no-op UPDATE on an
+      // already-member row can't refire the push.
+      if (!old_record) {
+        console.warn(
+          "send-push: memberships UPDATE arrived without old_record — " +
+            "verify the database webhook has 'Send old record' enabled. " +
+            "Falling back to dedupe-gated detection.",
+        );
+      }
+
+      const looksApproved =
+        newRole === "member" && (oldRole === "pending" || oldRole === undefined);
+      const looksDeclined =
+        newRole === "declined" && (oldRole === "pending" || oldRole === undefined);
+
+      const claimNotification = async (
+        kind: "approved" | "declined",
+      ): Promise<boolean> => {
+        // Insert-as-dedupe. The unique (membership_id, kind) index
+        // returns 23505 on duplicates — that's expected and means
+        // someone else already fired this push.
+        const { error } = await supabase
+          .from("membership_notifications_sent")
+          .insert({ membership_id: record.id, kind });
+        if (!error) return true;
+        if ((error as { code?: string }).code === "23505") return false;
+        console.error("membership dedupe claim failed:", error);
+        // Fail closed when the dedupe table is unreachable — better to
+        // miss one notification than to spam every UPDATE.
+        return false;
+      };
+
+      if (looksApproved && (await claimNotification("approved"))) {
         const { data: pg } = await supabase
           .from("playgroups")
           .select("name")
@@ -117,8 +153,7 @@ serve(async (req: Request) => {
         });
       }
 
-      // Request declined → notify the requester
-      if (oldRole === "pending" && newRole === "declined") {
+      if (looksDeclined && (await claimNotification("declined"))) {
         const { data: pg } = await supabase
           .from("playgroups")
           .select("name")

--- a/supabase/migrations/20260425000006_membership_notifications_dedupe.sql
+++ b/supabase/migrations/20260425000006_membership_notifications_dedupe.sql
@@ -1,0 +1,27 @@
+-- Dedupe table for membership-transition pushes.
+--
+-- send-push detects "join request approved/declined" by comparing
+-- old_record.role to record.role. If the webhook is misconfigured
+-- without "Send old record" enabled, old_record is undefined and
+-- the push silently never fires. Conversely, if we fall back to
+-- firing on record.role alone, an admin tool that touches a row
+-- without changing role would re-fire the push.
+--
+-- Solution: claim a (membership_id, kind) row before sending. The
+-- unique index turns "did we already notify this transition?" into
+-- a single atomic insert that is correct under concurrent edits.
+
+create table if not exists public.membership_notifications_sent (
+  id bigserial primary key,
+  membership_id uuid not null,
+  kind text not null check (kind in ('approved', 'declined')),
+  sent_at timestamptz not null default now(),
+  unique (membership_id, kind)
+);
+
+create index if not exists membership_notifications_sent_membership_idx
+  on public.membership_notifications_sent (membership_id);
+
+-- Service-role only; no RLS policies needed. RLS is enabled so that
+-- if anon/auth keys ever try to query it, they get nothing.
+alter table public.membership_notifications_sent enable row level security;


### PR DESCRIPTION
## Summary
Closes audit items **H7 + H8**. The memberships UPDATE branch in send-push detected approval/decline by comparing `old_record.role` to `record.role`, which broke silently when the webhook wasn't configured to send the old record, and would over-fire if we naively dropped the guard.

- New `membership_notifications_sent (membership_id, kind)` table with a unique index, used as an insert-as-dedupe claim before sending each push.
- Handler now treats `oldRole === "pending"` OR `oldRole === undefined` as an approval/decline transition, gated by the dedupe claim — so a no-op UPDATE on an existing member can't refire the push.
- Logs a warning when `old_record` is missing so misconfigured webhook setups are visible in function logs.

## Test plan
- [ ] Run migration
- [ ] Deploy `send-push`
- [ ] Approve a pending join request and confirm parent gets one push
- [ ] Re-trigger the same UPDATE (e.g. touch the row) and confirm no second push fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)