### PR TITLE
Hide phone_verified_at timestamp from other users (M8)

### DIFF
--- a/frontend/src/components/auth/RequireAuth.jsx
+++ b/frontend/src/components/auth/RequireAuth.jsx
@@ -35,7 +35,7 @@ export default function RequireAuth({ children }) {
   // to /verify-phone before we even know their state.
   if (
     profile &&
-    !profile.phone_verified_at &&
+    !profile.is_phone_verified &&
     !PHONE_VERIFY_EXEMPT.has(location.pathname)
   ) {
     return <Navigate to="/verify-phone" replace />;

--- a/frontend/src/components/profile/ProfilePanel.jsx
+++ b/frontend/src/components/profile/ProfilePanel.jsx
@@ -32,7 +32,7 @@ function ChildrenCard({ children }) {
 // unreliable on a brand-new network. Gate behind a prop when v2 lands.
 export default function ProfilePanel({ profile, onMessage }) {
   if (!profile) return null;
-  const verified = !!profile.phone_verified_at;
+  const verified = !!profile.is_phone_verified;
   const fullName = `${profile.first_name ?? ""} ${profile.last_name ?? ""}`.trim();
 
   return (

--- a/frontend/src/components/profile/ProfilePanel.test.jsx
+++ b/frontend/src/components/profile/ProfilePanel.test.jsx
@@ -6,7 +6,7 @@ const organizerSample = {
   first_name: "Priya",
   last_name: "Sharma",
   photo_url: null,
-  phone_verified_at: "2026-03-01T00:00:00Z",
+  is_phone_verified: true,
   account_type: "organizer",
   zip_code: "11530",
   bio: "First-time mom.",

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }) {
   const fetchProfile = async (userId) => {
     const { data, error } = await supabase
       .from("profiles")
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type, timezone")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, is_phone_verified, created_at, updated_at, notification_prefs, role, account_type, timezone")
       .eq("id", userId)
       .single();
 
@@ -150,7 +150,7 @@ export function AuthProvider({ children }) {
       .from("profiles")
       .update({ ...updates, updated_at: new Date().toISOString() })
       .eq("id", user.id)
-      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, phone_verified_at, created_at, updated_at, notification_prefs, role, account_type")
+      .select("id, first_name, last_name, bio, photo_url, philosophy_tags, trust_score, is_verified, is_phone_verified, created_at, updated_at, notification_prefs, role, account_type")
       .single();
 
     if (error) {

--- a/frontend/src/hooks/useSubscription.js
+++ b/frontend/src/hooks/useSubscription.js
@@ -95,7 +95,7 @@ export function useSubscription() {
 
   const joinRequestsUsed = usage?.request_count || 0;
   const joinRequestsRemaining = isPremium ? Infinity : Math.max(0, FREE_JOIN_LIMIT - joinRequestsUsed);
-  const canSendJoinRequest = (isPremium || joinRequestsRemaining > 0) && !!profile?.phone_verified_at;
+  const canSendJoinRequest = (isPremium || joinRequestsRemaining > 0) && !!profile?.is_phone_verified;
 
   return {
     // Joiner

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -60,7 +60,7 @@ export default function MyProfile() {
             {firstName} {lastName}
           </h2>
           <div className="flex flex-wrap justify-center gap-1.5 mt-1.5">
-            {profile?.phone_verified_at && (
+            {profile?.is_phone_verified && (
               <span className="inline-flex items-center gap-1 text-[11px] text-sage-dark bg-sage-light px-2 py-0.5 rounded-full">
                 <svg width="10" height="10" viewBox="0 0 20 20" fill="none">
                   <path d="M5 10l3 3 7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -67,7 +67,7 @@ function transformRealPlaygroup(pg) {
         (m.profiles?.last_name?.[0] || "").toUpperCase(),
       isHost: m.role === "creator",
       membership_role: m.role,
-      phone_verified_at: m.profiles?.phone_verified_at,
+      is_phone_verified: m.profiles?.is_phone_verified,
       account_type: m.profiles?.account_type,
       zip_code: m.profiles?.zip_code,
       bio: m.profiles?.bio,
@@ -169,7 +169,7 @@ export default function PlaygroupDetail() {
       .select(`
         *,
         profiles:creator_id ( first_name, last_name, bio, philosophy_tags, is_verified, trust_score ),
-        memberships ( user_id, role, profiles:user_id ( first_name, last_name, phone_verified_at, bio, philosophy_tags, account_type, zip_code, photo_url ) )
+        memberships ( user_id, role, profiles:user_id ( first_name, last_name, is_phone_verified, bio, philosophy_tags, account_type, zip_code, photo_url ) )
       `)
       .eq("id", id)
       .single();

--- a/supabase/migrations/20260425000007_phone_verified_privacy.sql
+++ b/supabase/migrations/20260425000007_phone_verified_privacy.sql
@@ -1,0 +1,18 @@
+-- Hide profiles.phone_verified_at from other users.
+--
+-- Today PlaygroupDetail joins profiles for every member and selects
+-- phone_verified_at to render a "Verified" badge. That timestamp is
+-- meaningful — it tells anyone in the group when each user verified
+-- their phone, which is more than they need to know. The boolean
+-- "is this user phone-verified?" is enough for any UI we render.
+--
+-- Fix: expose a generated boolean column is_phone_verified, and
+-- revoke column-level SELECT on phone_verified_at from anon and
+-- authenticated. service_role retains access (used by verify-otp
+-- and submit-join-request edge functions).
+
+alter table public.profiles
+  add column if not exists is_phone_verified boolean
+  generated always as (phone_verified_at is not null) stored;
+
+revoke select (phone_verified_at) on public.profiles from anon, authenticated;


### PR DESCRIPTION
## Summary
Closes audit item **M8**. PlaygroupDetail joined profiles for every member and selected `phone_verified_at` to render a "Verified" badge — but every group member was thereby told when each other member verified their phone. The UI only ever uses the boolean.

- Adds generated boolean `is_phone_verified` column on `profiles`
- Revokes column-level SELECT on `phone_verified_at` from `anon` and `authenticated`; `service_role` retains access for `verify-otp` and `submit-join-request`
- Swaps frontend reads to `is_phone_verified` (AuthContext, RequireAuth, ProfilePanel, MyProfile, PlaygroupDetail, useSubscription, test mocks)

**Run migration BEFORE merging** — the frontend now reads `is_phone_verified` which only exists after the migration. The migration must run first or the live site will see undefined verification status until it does.

## Test plan
- [ ] Run migration in Supabase SQL editor
- [ ] Merge + Netlify deploys
- [ ] Confirm "Phone verified" badge still renders on MyProfile
- [ ] Confirm phone-verification gate on join still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)