### PR TITLE
Log each cron tick to cron_run_log (H3)

### DIFF
--- a/supabase/functions/send-session-reminders/index.ts
+++ b/supabase/functions/send-session-reminders/index.ts
@@ -231,6 +231,16 @@ async function sendReminder(r: Reminder): Promise<boolean> {
 }
 
 serve(async (_req) => {
+  // Open a cron_run_log row up front so even a hard crash mid-run leaves
+  // a started_at marker — drift detection just looks for stale rows
+  // with completed_at IS NULL or a too-old most-recent started_at.
+  const { data: logRow } = await admin
+    .from("cron_run_log")
+    .insert({ function_name: "send-session-reminders" })
+    .select("id")
+    .single();
+  const runId = logRow?.id as number | undefined;
+
   try {
     // The 24h and 2h windows are independent queries — fetch them in
     // parallel so a slow round-trip on one doesn't push the other past
@@ -259,6 +269,20 @@ serve(async (_req) => {
       }
     }
 
+    if (runId) {
+      await admin
+        .from("cron_run_log")
+        .update({
+          completed_at: new Date().toISOString(),
+          candidates: allReminders.length,
+          premium: premium.length,
+          sent,
+          skipped,
+          failed,
+        })
+        .eq("id", runId);
+    }
+
     return new Response(
       JSON.stringify({
         candidates: allReminders.length,
@@ -274,6 +298,15 @@ serve(async (_req) => {
     // hiccup mid-loop, malformed row) doesn't 502 the cron — the next
     // tick can recover the missed window since dedupe is per-(session,user,kind).
     console.error("send-session-reminders top-level error:", err);
+    if (runId) {
+      await admin
+        .from("cron_run_log")
+        .update({
+          completed_at: new Date().toISOString(),
+          error: String(err).slice(0, 500),
+        })
+        .eq("id", runId);
+    }
     return new Response(
       JSON.stringify({ error: String(err) }),
       { status: 500, headers: { "Content-Type": "application/json" } },

--- a/supabase/migrations/20260425000008_cron_run_log.sql
+++ b/supabase/migrations/20260425000008_cron_run_log.sql
@@ -1,0 +1,36 @@
+-- Per-tick log for scheduled edge functions.
+--
+-- send-session-reminders is invoked by pg_cron every ~10 min. If the
+-- cron job stalls (e.g. function crash, schedule deleted, vault
+-- secret rotated and not updated) we currently have no way to notice
+-- short of a user complaint about missing reminders. The function
+-- logs in the dashboard are also flushed after a couple of days.
+--
+-- This table writes one row per invocation with start/end timestamps
+-- and a counter snapshot, so a one-line query
+--   select * from cron_run_log
+--   where function_name = 'send-session-reminders'
+--   order by started_at desc limit 5;
+-- tells you whether the cron is alive and what it's been doing.
+--
+-- Designed to be reused by future scheduled functions — the
+-- function_name column lets multiple crons share the table.
+
+create table if not exists public.cron_run_log (
+  id bigserial primary key,
+  function_name text not null,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  candidates integer,
+  premium integer,
+  sent integer,
+  skipped integer,
+  failed integer,
+  error text
+);
+
+create index if not exists cron_run_log_function_started_idx
+  on public.cron_run_log (function_name, started_at desc);
+
+-- service-role only
+alter table public.cron_run_log enable row level security;


### PR DESCRIPTION
## Summary
Closes audit item **H3**. Adds a per-tick log so we can see at a glance whether `send-session-reminders` is alive and what it's been doing — the dashboard's function logs roll over after ~2 days and a stalled cron is otherwise silent.

- New `cron_run_log` table reusable by future scheduled functions
- `send-session-reminders` opens a row up front (so a hard crash still leaves a `started_at` marker), then updates counters on success or `error` text on the catch path

Drift query:
```sql
select * from cron_run_log
where function_name = 'send-session-reminders'
order by started_at desc limit 5;
```

## Test plan
- [ ] Run migration
- [ ] Deploy `send-session-reminders`
- [ ] Wait ~10 min, query `cron_run_log` and confirm rows appear with sensible counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)