### PR TITLE
Cross-reference duplicated FREE_JOIN_LIMIT (L3)

### DIFF
--- a/frontend/src/hooks/useSubscription.js
+++ b/frontend/src/hooks/useSubscription.js
@@ -2,6 +2,9 @@ import { useState, useEffect } from "react";
 import { supabase } from "../lib/supabase";
 import { useAuth } from "../context/AuthContext";
 
+// Mirror of FREE_JOIN_LIMIT in supabase/functions/submit-join-request/index.ts.
+// The server is authoritative — this constant only drives the UI's
+// "X requests left" copy. If you change one, change the other.
 const FREE_JOIN_LIMIT = 1;
 
 export function useSubscription() {

--- a/supabase/functions/submit-join-request/index.ts
+++ b/supabase/functions/submit-join-request/index.ts
@@ -26,6 +26,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
+// Mirror of FREE_JOIN_LIMIT in frontend/src/hooks/useSubscription.js.
+// This is the authoritative value; the frontend copy only drives UI
+// copy ("X requests left"). If you change one, change the other.
 const FREE_JOIN_LIMIT = 1;
 
 const corsHeaders = {


### PR DESCRIPTION
## Summary
Closes audit item **L3** (and acks **L1** as already fine — `send-push` has no CORS headers at all).

`FREE_JOIN_LIMIT` lives in both `submit-join-request` (authoritative server check) and `useSubscription` (UI "X left" counter). A shared module isn't practical across the Deno edge / Vite frontend split, so just document the coupling at both sites so future edits don't drift.

No deploy needed — comments only. Merging directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)