### PR TITLE
Phase 2 v1: verified-host trust tier + browse filter

### DIFF
--- a/frontend/src/components/browse/FilterSheet.jsx
+++ b/frontend/src/components/browse/FilterSheet.jsx
@@ -52,13 +52,25 @@ export default function FilterSheet({ open, onClose, filters, onChange, isPremiu
     onChange({ ...filters, [key]: next });
   };
 
-  const activeCount = Object.values(filters).reduce(
-    (sum, arr) => sum + arr.length,
-    0
-  );
+  const activeCount =
+    (filters.vibeTags?.length || 0) +
+    (filters.ageRange?.length || 0) +
+    (filters.setting?.length || 0) +
+    (filters.accessType?.length || 0) +
+    (filters.verifiedOnly ? 1 : 0);
 
   const clearAll = () => {
-    onChange({ vibeTags: [], ageRange: [], setting: [], accessType: [] });
+    onChange({
+      vibeTags: [],
+      ageRange: [],
+      setting: [],
+      accessType: [],
+      verifiedOnly: false,
+    });
+  };
+
+  const toggleVerifiedOnly = () => {
+    onChange({ ...filters, verifiedOnly: !filters.verifiedOnly });
   };
 
   const PremiumLock = () => (
@@ -152,6 +164,39 @@ export default function FilterSheet({ open, onClose, filters, onChange, isPremiu
               selected={filters.accessType}
               onToggle={(v) => toggle("accessType", v)}
             />
+
+            {/* Trust — verified hosts only. Free for everyone since
+                trust-and-safety filters shouldn't be paywalled. */}
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-charcoal">Trust</label>
+              <button
+                type="button"
+                onClick={toggleVerifiedOnly}
+                className={`flex items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-left cursor-pointer transition-colors border ${
+                  filters.verifiedOnly
+                    ? "bg-blue-50 border-blue-300 text-blue-800"
+                    : "bg-cream-dark border-transparent text-charcoal hover:border-sage-light"
+                }`}
+              >
+                <span className="flex items-center gap-2 text-xs font-medium">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+                  </svg>
+                  Verified hosts only
+                </span>
+                <span
+                  className={`relative w-9 h-5 rounded-full transition-colors ${
+                    filters.verifiedOnly ? "bg-blue-600" : "bg-cream"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                      filters.verifiedOnly ? "translate-x-[18px]" : "translate-x-0.5"
+                    }`}
+                  />
+                </span>
+              </button>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -36,6 +36,7 @@ export default function Browse() {
     ageRange: [],
     setting: [],
     accessType: [],
+    verifiedOnly: false,
   });
 
   const { userLocation, loading: locationLoading, error: locationError, requestLocation } = useUserLocation();
@@ -130,11 +131,14 @@ export default function Browse() {
 
   const allPlaygroups = useMemo(() => realPlaygroups, [realPlaygroups]);
 
-  // Count active filters
-  const activeFilterCount = Object.values(filters).reduce(
-    (sum, arr) => sum + arr.length,
-    0
-  );
+  // Count active filters. verifiedOnly is a boolean, not an array, so
+  // sum it separately.
+  const activeFilterCount =
+    filters.vibeTags.length +
+    filters.ageRange.length +
+    filters.setting.length +
+    filters.accessType.length +
+    (filters.verifiedOnly ? 1 : 0);
 
   // Tag and (for free users) gate newly-posted groups. Computed in the
   // memo so the cutoff stays fresh as time passes between fetches.
@@ -196,6 +200,11 @@ export default function Browse() {
     // Access type filter
     if (filters.accessType.length > 0) {
       list = list.filter((g) => filters.accessType.includes(g.accessType));
+    }
+
+    // Verified hosts only
+    if (filters.verifiedOnly) {
+      list = list.filter((g) => g.verified);
     }
 
     // Compute distance if user location is available

--- a/frontend/src/pages/admin/UserDetailPanel.jsx
+++ b/frontend/src/pages/admin/UserDetailPanel.jsx
@@ -16,8 +16,36 @@ export default function UserDetailPanel({
   const [children, setChildren] = useState([]);
   const [memberships, setMemberships] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Local mirror of is_verified so the badge updates without re-fetching
+  // the parent list. The DB trigger check_is_verified_escalation enforces
+  // that only admins can actually flip it; the button is gated by the
+  // Admin route, but the trigger is the real guard.
+  const [verified, setVerified] = useState(!!profile.is_verified);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyError, setVerifyError] = useState("");
 
   const isSuspended = !!profile.is_suspended;
+
+  const toggleVerified = async () => {
+    const next = !verified;
+    const action = next ? "verify" : "unverify";
+    if (!window.confirm(`${next ? "Mark as verified" : "Remove verified status"} for ${profile.first_name || "this user"}?`)) {
+      return;
+    }
+    setVerifying(true);
+    setVerifyError("");
+    const { error } = await supabase
+      .from("profiles")
+      .update({ is_verified: next })
+      .eq("id", profile.id);
+    setVerifying(false);
+    if (error) {
+      console.error(`Failed to ${action} user:`, error);
+      setVerifyError(error.message || `Couldn't ${action} this user.`);
+      return;
+    }
+    setVerified(next);
+  };
 
   useEffect(() => {
     if (!profile?.id) return;
@@ -99,7 +127,7 @@ export default function UserDetailPanel({
             <div className="flex items-center justify-center gap-2 mt-1">
               {role !== "none" && <StatusBadge status={role} />}
               {isSuspended && <StatusBadge status="suspended" />}
-              {profile.is_verified && (
+              {verified && (
                 <span className="text-[10px] bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
                   Verified
                 </span>
@@ -168,6 +196,26 @@ export default function UserDetailPanel({
                 <p className="text-[11px] text-taupe">Reports Against</p>
               </div>
             </div>
+
+            <button
+              type="button"
+              onClick={toggleVerified}
+              disabled={verifying}
+              className={`mt-3 w-full text-sm font-medium rounded-xl px-4 py-2.5 border transition-colors cursor-pointer ${
+                verified
+                  ? "bg-white border-cream-dark text-charcoal hover:bg-cream"
+                  : "bg-blue-600 border-blue-600 text-white hover:bg-blue-700"
+              } ${verifying ? "opacity-60 cursor-wait" : ""}`}
+            >
+              {verifying
+                ? "Saving..."
+                : verified
+                ? "Remove verified status"
+                : "Mark as verified"}
+            </button>
+            {verifyError && (
+              <p className="text-xs text-red-600 mt-2 text-center">{verifyError}</p>
+            )}
           </div>
 
           {/* Children */}

--- a/supabase/migrations/20260425000009_verified_host_guard.sql
+++ b/supabase/migrations/20260425000009_verified_host_guard.sql
@@ -1,0 +1,27 @@
+-- Lock is_verified to admin-only writes.
+--
+-- profiles.is_verified is the trust-tier flag — it gates the
+-- "Verified" badge on PlaygroupCard / PlaygroupDetail and (with PR-N)
+-- the "Verified hosts only" Browse filter. Without this guard, any
+-- user can self-update their profile and flip themselves to verified,
+-- defeating the whole point of the badge.
+--
+-- Mirrors the prevent_role_escalation trigger from migration 011.
+
+create or replace function public.prevent_is_verified_escalation()
+returns trigger as $$
+begin
+  if new.is_verified is distinct from old.is_verified
+     and not public.is_admin() then
+    raise exception 'Only admins can change verification status';
+  end if;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+drop trigger if exists check_is_verified_escalation on public.profiles;
+
+create trigger check_is_verified_escalation
+  before update on public.profiles
+  for each row
+  execute function public.prevent_is_verified_escalation();


### PR DESCRIPTION
## Summary
First Phase 2 deliverable — make the dormant `is_verified` flag actually usable end-to-end.

**DB**
- `prevent_is_verified_escalation` trigger: only admins can flip `is_verified`. Mirrors the role-escalation guard from migration 011.

**Admin (UserDetailPanel)**
- "Mark as verified" / "Remove verified status" button with a confirm dialog
- Local state mirror so the badge updates inline

**Browse**
- "Verified hosts only" toggle in FilterSheet under a new Trust section
- Free for all (trust filters shouldn't be paywalled)
- Pipeline + `activeFilterCount` updated for the new boolean

## Test plan
- [ ] Run the migration in Supabase SQL editor
- [ ] As a non-admin, attempt `update profiles set is_verified = true where id = auth.uid()` — should error
- [ ] As admin, open Admin → Users → pick a user → tap "Mark as verified" — badge appears
- [ ] On Browse, open Filters → enable "Verified hosts only" — only verified-host playgroups show
- [ ] Verify host badge still renders on PlaygroupDetail and PlaygroupCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)