### PR TITLE
PR-O: host verification request flow

### DIFF
--- a/frontend/src/components/profile/HostVerificationCard.jsx
+++ b/frontend/src/components/profile/HostVerificationCard.jsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from "react";
+import { supabase } from "../../lib/supabase";
+
+// Shows the host's current verification standing and a "Request
+// verification" CTA. Hidden entirely for non-hosts since the badge
+// only renders in host contexts (PlaygroupCard, PlaygroupDetail).
+//
+// States:
+//   verified=true                   → green badge, no CTA
+//   latest request status=pending   → "Under review" pill
+//   latest request status=rejected  → "Declined" pill + re-request button
+//   nothing                         → "Request verification" button
+export default function HostVerificationCard({ userId, isVerified }) {
+  const [latest, setLatest] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchLatest = async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("verification_requests")
+      .select("id, status, submitted_at, reviewed_at, notes")
+      .eq("user_id", userId)
+      .order("submitted_at", { ascending: false })
+      .limit(1);
+    setLatest(data?.[0] || null);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (!userId) return;
+    fetchLatest();
+  }, [userId]);
+
+  const submitRequest = async () => {
+    setSubmitting(true);
+    setError("");
+    const { error: err } = await supabase
+      .from("verification_requests")
+      .insert({ user_id: userId });
+    setSubmitting(false);
+    if (err) {
+      console.error("Failed to submit verification request:", err);
+      // 23505 = unique-violation from one_pending_per_user_idx
+      if (err.code === "23505") {
+        setError("You already have a request under review.");
+      } else {
+        setError(err.message || "Couldn't submit your request.");
+      }
+      return;
+    }
+    fetchLatest();
+  };
+
+  if (!userId || loading) return null;
+
+  const statusPill = (text, tone) => (
+    <span
+      className={`inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-full ${
+        tone === "green"
+          ? "bg-sage-light text-sage-dark"
+          : tone === "amber"
+          ? "bg-amber-50 text-amber-700"
+          : "bg-cream-dark text-taupe"
+      }`}
+    >
+      {text}
+    </span>
+  );
+
+  return (
+    <div className="bg-white rounded-2xl border border-cream-dark p-5">
+      <div className="flex items-start gap-3">
+        <div className="w-10 h-10 rounded-xl bg-blue-50 flex items-center justify-center shrink-0">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+              stroke="#1d4ed8"
+              strokeWidth="1.5"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-heading font-bold text-charcoal">
+            Host verification
+          </h3>
+          {isVerified ? (
+            <>
+              <p className="text-xs text-taupe mt-0.5 leading-relaxed">
+                Your profile shows a Verified badge to parents browsing your group.
+              </p>
+              <div className="mt-2">
+                {statusPill("✓ Verified", "green")}
+              </div>
+            </>
+          ) : latest?.status === "pending" ? (
+            <>
+              <p className="text-xs text-taupe mt-0.5 leading-relaxed">
+                We're reviewing your request. This usually takes a few days.
+              </p>
+              <div className="mt-2">{statusPill("Under review", "amber")}</div>
+            </>
+          ) : latest?.status === "rejected" ? (
+            <>
+              <p className="text-xs text-taupe mt-0.5 leading-relaxed">
+                Your previous request wasn't approved. You can submit a new one anytime.
+                {latest.notes ? (
+                  <span className="block mt-1 italic">Reviewer note: {latest.notes}</span>
+                ) : null}
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                {statusPill("Declined", "neutral")}
+                <button
+                  type="button"
+                  onClick={submitRequest}
+                  disabled={submitting}
+                  className="text-xs bg-blue-600 text-white font-medium rounded-lg px-3 py-1.5 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-wait cursor-pointer"
+                >
+                  {submitting ? "Submitting..." : "Request again"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-xs text-taupe mt-0.5 leading-relaxed">
+                Verified hosts get a badge on their group and appear in the trusted-hosts filter.
+              </p>
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={submitRequest}
+                  disabled={submitting}
+                  className="text-xs bg-blue-600 text-white font-medium rounded-lg px-3 py-1.5 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-wait cursor-pointer"
+                >
+                  {submitting ? "Submitting..." : "Request verification"}
+                </button>
+              </div>
+            </>
+          )}
+          {error && (
+            <p className="text-xs text-red-600 mt-2">{error}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -10,6 +10,7 @@ import PlaygroupsTab from "./admin/PlaygroupsTab";
 import ReportsTab from "./admin/ReportsTab";
 import ReviewsTab from "./admin/ReviewsTab";
 import RequestsTab from "./admin/RequestsTab";
+import VerificationsTab from "./admin/VerificationsTab";
 import SubscriptionsTab from "./admin/SubscriptionsTab";
 import AnalyticsTab from "./admin/AnalyticsTab";
 import AuditLogTab from "./admin/AuditLogTab";
@@ -52,6 +53,10 @@ export default function Admin() {
   // this at the start and sets it on failure so the admin sees ground
   // truth instead of an optimistic-then-silent no-op.
   const [adminError, setAdminError] = useState("");
+  // Sidebar badge count for the Verifications tab. Owned here so the
+  // count survives across tab switches; VerificationsTab refreshes it
+  // after each approve/reject.
+  const [pendingVerifications, setPendingVerifications] = useState(0);
 
   useEffect(() => {
     if (authLoading) return;
@@ -73,6 +78,7 @@ export default function Admin() {
         fetchSubscriptions(),
         fetchAuditLog(),
         fetchAdminStats(),
+        fetchPendingVerificationCount(),
       ]);
     } catch (err) {
       console.error("Admin fetch error:", err);
@@ -187,6 +193,14 @@ export default function Admin() {
     if (!error && data) {
       setSubscriptions(data);
     }
+  }
+
+  async function fetchPendingVerificationCount() {
+    const { count } = await supabase
+      .from("verification_requests")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending");
+    setPendingVerifications(count || 0);
   }
 
   async function fetchAuditLog() {
@@ -580,6 +594,7 @@ export default function Admin() {
     { key: "reports", label: "Reports", icon: "flag", badge: stats.openReports },
     { key: "reviews", label: "Reviews", icon: "rate_review" },
     { key: "requests", label: "Requests", icon: "pending_actions" },
+    { key: "verifications", label: "Verifications", icon: "verified", badge: pendingVerifications },
     { key: "subscriptions", label: "Subscriptions", icon: "payments" },
     { key: "analytics", label: "Analytics", icon: "analytics" },
     { key: "audit", label: "Audit Log", icon: "history" },
@@ -946,6 +961,10 @@ export default function Admin() {
 
           {!loading && activeSection === "requests" && (
             <RequestsTab recentRequests={recentRequests} />
+          )}
+
+          {!loading && activeSection === "verifications" && (
+            <VerificationsTab onPendingCountChange={setPendingVerifications} />
           )}
 
           {!loading && activeSection === "subscriptions" && (

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../context/AuthContext";
 import { supabase } from "../lib/supabase";
 import { useSubscription } from "../hooks/useSubscription";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import HostVerificationCard from "../components/profile/HostVerificationCard";
 
 export default function MyProfile() {
   useDocumentTitle("My Profile"); // #50
@@ -101,6 +102,13 @@ export default function MyProfile() {
             </div>
           )}
         </div>
+
+        {isHost && (
+          <HostVerificationCard
+            userId={user?.id}
+            isVerified={!!profile?.is_verified}
+          />
+        )}
 
         {/* Settings list */}
         <div className="bg-white rounded-2xl border border-cream-dark overflow-hidden">

--- a/frontend/src/pages/admin/VerificationsTab.jsx
+++ b/frontend/src/pages/admin/VerificationsTab.jsx
@@ -1,0 +1,200 @@
+import { useState, useEffect } from "react";
+import { supabase } from "../../lib/supabase";
+import { timeAgo } from "./timeAgo";
+
+// Self-contained tab — fetches its own queue rather than threading
+// state through Admin.jsx, since the data only matters when this tab
+// is open. Pending count is also surfaced as a sidebar badge via the
+// optional onPendingCountChange prop.
+export default function VerificationsTab({ onPendingCountChange }) {
+  const [filter, setFilter] = useState("pending");
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [actingId, setActingId] = useState(null);
+  const [error, setError] = useState("");
+
+  const fetchRequests = async () => {
+    setLoading(true);
+    const { data, error: err } = await supabase
+      .from("verification_requests")
+      .select(`
+        id, status, submitted_at, reviewed_at, notes,
+        profiles:user_id ( id, first_name, last_name, photo_url, bio, trust_score, is_verified )
+      `)
+      .eq("status", filter)
+      .order("submitted_at", { ascending: false })
+      .limit(100);
+
+    if (err) {
+      console.error("Failed to fetch verification requests:", err);
+      setError("Couldn't load requests.");
+      setLoading(false);
+      return;
+    }
+    setRequests(data || []);
+    setLoading(false);
+
+    // Refresh sidebar pending count alongside.
+    if (onPendingCountChange) {
+      const { count } = await supabase
+        .from("verification_requests")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "pending");
+      onPendingCountChange(count || 0);
+    }
+  };
+
+  useEffect(() => {
+    fetchRequests();
+  }, [filter]);
+
+  const handleDecision = async (req, decision) => {
+    const verb = decision === "approved" ? "approve" : "reject";
+    if (!window.confirm(`${decision === "approved" ? "Approve" : "Reject"} verification for ${req.profiles?.first_name || "this user"}?`)) {
+      return;
+    }
+    setActingId(req.id);
+    setError("");
+
+    // Update the request row first. If this fails (e.g. RLS denial),
+    // we abort before touching the profile so we don't leave the two
+    // out of sync.
+    const { error: reqErr } = await supabase
+      .from("verification_requests")
+      .update({
+        status: decision,
+        reviewed_at: new Date().toISOString(),
+        reviewer_id: (await supabase.auth.getUser()).data.user?.id,
+      })
+      .eq("id", req.id);
+
+    if (reqErr) {
+      console.error(`Failed to ${verb} request:`, reqErr);
+      setError(reqErr.message || `Couldn't ${verb} the request.`);
+      setActingId(null);
+      return;
+    }
+
+    // On approval, flip the profile flag — admin role lets us through
+    // the prevent_is_verified_escalation trigger.
+    if (decision === "approved" && req.profiles?.id) {
+      const { error: profErr } = await supabase
+        .from("profiles")
+        .update({ is_verified: true })
+        .eq("id", req.profiles.id);
+      if (profErr) {
+        console.error("Verified the request but failed to flip profile flag:", profErr);
+        setError("Request marked approved, but profile flag update failed. Re-try from the user panel.");
+      }
+    }
+
+    setActingId(null);
+    fetchRequests();
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between mb-1 gap-2 flex-wrap">
+        <h2 className="font-heading text-lg font-semibold text-charcoal">
+          Verification Requests
+        </h2>
+        <div className="flex items-center gap-2">
+          {["pending", "approved", "rejected"].map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => setFilter(s)}
+              className={`text-xs px-3 py-1.5 rounded-full font-medium border transition-colors cursor-pointer ${
+                filter === s
+                  ? "bg-charcoal text-white border-charcoal"
+                  : "bg-white text-charcoal border-cream-dark hover:bg-cream"
+              }`}
+            >
+              {s[0].toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-xl px-4 py-3">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="bg-white rounded-2xl border border-cream-dark p-8 text-center">
+          <p className="text-taupe text-sm">Loading...</p>
+        </div>
+      ) : requests.length === 0 ? (
+        <div className="bg-white rounded-2xl border border-cream-dark p-8 text-center">
+          <p className="text-taupe text-sm">No {filter} requests.</p>
+        </div>
+      ) : (
+        requests.map((req) => {
+          const p = req.profiles || {};
+          const fullName = `${p.first_name || ""} ${p.last_name || ""}`.trim() || "Unknown user";
+          const initials =
+            (p.first_name?.[0] || "?").toUpperCase() +
+            (p.last_name?.[0] || "").toUpperCase();
+          return (
+            <div key={req.id} className="bg-white rounded-2xl border border-cream-dark p-4">
+              <div className="flex items-start gap-3">
+                <div className="w-12 h-12 rounded-full bg-sage-light flex items-center justify-center shrink-0 text-sage-dark font-bold text-sm">
+                  {p.photo_url ? (
+                    <img src={p.photo_url} alt="" className="w-full h-full rounded-full object-cover" />
+                  ) : (
+                    initials
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-sm font-medium text-charcoal truncate">{fullName}</p>
+                    <span className="text-xs text-taupe whitespace-nowrap shrink-0">
+                      {timeAgo(req.submitted_at)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-taupe mt-0.5">
+                    Trust score {p.trust_score || 0}
+                    {p.is_verified && " · already verified"}
+                  </p>
+                  {p.bio && (
+                    <p className="text-xs text-charcoal/80 mt-2 leading-relaxed line-clamp-3">
+                      {p.bio}
+                    </p>
+                  )}
+                  {req.notes && (
+                    <p className="text-xs text-taupe mt-2 italic">
+                      Note: {req.notes}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {filter === "pending" && (
+                <div className="flex gap-2 mt-3">
+                  <button
+                    type="button"
+                    onClick={() => handleDecision(req, "approved")}
+                    disabled={actingId === req.id}
+                    className="flex-1 bg-blue-600 text-white text-sm font-medium rounded-xl px-3 py-2 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-wait cursor-pointer"
+                  >
+                    {actingId === req.id ? "..." : "Approve"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDecision(req, "rejected")}
+                    disabled={actingId === req.id}
+                    className="flex-1 bg-white border border-cream-dark text-charcoal text-sm font-medium rounded-xl px-3 py-2 hover:bg-cream disabled:opacity-60 disabled:cursor-wait cursor-pointer"
+                  >
+                    Reject
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260425000010_verification_requests.sql
+++ b/supabase/migrations/20260425000010_verification_requests.sql
@@ -1,0 +1,53 @@
+-- Host verification request flow.
+--
+-- PR-N gave admins the power to flip is_verified, but discovery of
+-- "who should be verified" relied on admins poking around. This
+-- table is the queue: hosts submit a request, admins approve or
+-- reject in the new Verifications tab. On approval, the admin click
+-- also sets profiles.is_verified=true via the existing trigger
+-- (which permits admin writes).
+
+create table if not exists public.verification_requests (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  status text not null default 'pending'
+    check (status in ('pending', 'approved', 'rejected')),
+  submitted_at timestamptz not null default now(),
+  reviewed_at timestamptz,
+  reviewer_id uuid references auth.users (id),
+  notes text
+);
+
+-- One open request per user. Re-requesting after a decision is fine
+-- — those rows have status != 'pending' and are excluded from the
+-- partial unique index.
+create unique index if not exists verification_requests_one_pending_per_user_idx
+  on public.verification_requests (user_id)
+  where status = 'pending';
+
+-- Admin queue ordering — newest pending first.
+create index if not exists verification_requests_status_submitted_idx
+  on public.verification_requests (status, submitted_at desc);
+
+alter table public.verification_requests enable row level security;
+
+-- Users can read their own requests (drives the MyProfile status pill).
+create policy "Users can read own verification requests"
+  on public.verification_requests for select
+  using (auth.uid() = user_id);
+
+-- Users can insert a request for themselves. The check constraint
+-- + partial unique index together ensure they can't sneak in
+-- 'approved' status or stack multiple pending rows.
+create policy "Users can submit own verification request"
+  on public.verification_requests for insert
+  with check (auth.uid() = user_id and status = 'pending');
+
+-- Admins can read all and update any.
+create policy "Admins can read all verification requests"
+  on public.verification_requests for select
+  using (public.is_admin());
+
+create policy "Admins can update verification requests"
+  on public.verification_requests for update
+  using (public.is_admin());


### PR DESCRIPTION
## Summary
Closes the loop on Phase 2: hosts can now request verification themselves, and admins triage from a dedicated tab. Builds on PR-N.

**DB**
- `verification_requests (id, user_id, status, submitted_at, reviewed_at, reviewer_id, notes)`
- Partial unique index keeps one pending row per user
- RLS: users read/insert their own pending row; admins read all and update any

**Host (MyProfile)**
- `HostVerificationCard` shown only to hosts
- Four states: verified · under review · declined (with re-request) · none

**Admin**
- New Verifications sidebar tab with pending count badge
- Pending/Approved/Rejected filters
- One-click Approve (also flips `is_verified=true`) or Reject

## Test plan
- [ ] Run migration
- [ ] As host, MyProfile shows "Request verification" → tap → status flips to "Under review"
- [ ] As admin, Admin → Verifications shows the request → tap Approve → host's MyProfile flips to verified
- [ ] Confirm a second request submission while pending returns the friendly "already under review" copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)