### PR TITLE
PR-P: push notification on verification status change

### DIFF
--- a/frontend/src/pages/NotificationSettings.jsx
+++ b/frontend/src/pages/NotificationSettings.jsx
@@ -74,6 +74,16 @@ const NOTIFICATION_TYPES = [
       </svg>
     ),
   },
+  {
+    key: "verifications",
+    label: "Verification Updates",
+    description: "When your host verification request is approved or declined",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
 ];
 
 const DEFAULT_PREFS = {
@@ -83,6 +93,7 @@ const DEFAULT_PREFS = {
   sessions: true,
   rsvps: true,
   session_reminders: true,
+  verifications: true,
 };
 
 export default function NotificationSettings() {

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -40,6 +40,7 @@ serve(async (req: Request) => {
       | "membership_updates"
       | "sessions"
       | "rsvps"
+      | "verifications"
       | null;
     let notifications: {
       userId: string;
@@ -293,6 +294,36 @@ serve(async (req: Request) => {
             kind: "sessions",
           });
         }
+      }
+    }
+
+    if (table === "verification_requests" && type === "UPDATE") {
+      // Host verification status changed. Fire one push to the
+      // requester on the pending → approved/rejected transition so
+      // they don't have to keep checking MyProfile to find out.
+      const oldStatus = old_record?.status;
+      const newStatus = record.status;
+      if (oldStatus === "pending" && newStatus === "approved") {
+        notifications.push({
+          userId: record.user_id as string,
+          title: "You're verified ✓",
+          body: "Your host profile now shows the Verified badge.",
+          url: "/me",
+          tag: `verification-${record.id}`,
+          kind: "verifications",
+        });
+      } else if (oldStatus === "pending" && newStatus === "rejected") {
+        const note = (record.notes as string | null)?.trim();
+        notifications.push({
+          userId: record.user_id as string,
+          title: "Verification update",
+          body: note
+            ? `Your request wasn't approved: ${note.slice(0, 140)}`
+            : "Your verification request wasn't approved this time.",
+          url: "/me",
+          tag: `verification-${record.id}`,
+          kind: "verifications",
+        });
       }
     }
 

--- a/supabase/migrations/20260425000011_notification_prefs_add_verifications.sql
+++ b/supabase/migrations/20260425000011_notification_prefs_add_verifications.sql
@@ -1,0 +1,33 @@
+-- Allow 'verifications' as a valid key in profiles.notification_prefs.
+--
+-- PR-I locked the column shape via is_valid_notification_prefs() with
+-- a fixed key list. PR-P adds a new notification kind for host
+-- verification approve/reject pushes, so the function needs the
+-- enumerated list extended or NotificationSettings can't save the
+-- toggle.
+
+create or replace function public.is_valid_notification_prefs(p jsonb)
+returns boolean
+language sql
+immutable
+as $$
+  select
+    p is null
+    or (
+      jsonb_typeof(p) = 'object'
+      and not exists (
+        select 1
+        from jsonb_each(p) as e
+        where e.key not in (
+            'messages',
+            'join_requests',
+            'membership_updates',
+            'sessions',
+            'rsvps',
+            'session_reminders',
+            'verifications'
+          )
+           or jsonb_typeof(e.value) <> 'boolean'
+      )
+    );
+$$;


### PR DESCRIPTION
## Summary
Closes the PR-O loop — when an admin approves or rejects a verification request the host gets a push, instead of having to keep checking MyProfile.

**DB**
- Extends `is_valid_notification_prefs` to allow a new `verifications` key (PR-I's CHECK constraint enumerated the valid keys)

**send-push**
- New `verification_requests` UPDATE branch fires once on the pending → approved/rejected transition
- `kind: "verifications"` so it respects the per-user toggle
- Tag keyed on request id for device-level coalescing

**Frontend**
- NotificationSettings gains a "Verification Updates" toggle, default on

## Required dashboard config
A new database webhook needs to be added in the Supabase dashboard:
- **Table**: `verification_requests`
- **Events**: UPDATE
- **Send old record**: ON
- **URL**: `https://pdgtryghvibhmmroqvdk.supabase.co/functions/v1/send-push`
- **HTTP Headers**: same Authorization Bearer pattern as the other webhooks

## Test plan
- [ ] Run migration
- [ ] Deploy `send-push`
- [ ] Add the webhook in the dashboard
- [ ] As admin, approve a host verification request → host's device gets a "You're verified ✓" push
- [ ] Confirm toggling the Verification Updates switch in NotificationSettings suppresses future pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)