### PR TITLE
PR-R: verified-only sessions

### DIFF
--- a/frontend/src/components/host/ScheduleSessionSheet.jsx
+++ b/frontend/src/components/host/ScheduleSessionSheet.jsx
@@ -34,6 +34,10 @@ export default function ScheduleSessionSheet({
   // onSchedule. Copy and button labels shift accordingly.
   existingSession = null,
   onUpdate,
+  // Hosts can only restrict a session to verified parents if they
+  // themselves are verified — otherwise the trust signal is empty.
+  // Parent toggles visibility based on this flag.
+  hostIsVerified = false,
 }) {
   const isEdit = !!existingSession;
   const [date, setDate] = useState("");
@@ -41,6 +45,7 @@ export default function ScheduleSessionSheet({
   const [duration, setDuration] = useState(120);
   const [location, setLocation] = useState(defaultLocation);
   const [notes, setNotes] = useState("");
+  const [requiresVerified, setRequiresVerified] = useState(false);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [confirmOvernight, setConfirmOvernight] = useState(false);
@@ -56,6 +61,7 @@ export default function ScheduleSessionSheet({
     setDuration(existingSession.duration_minutes || 120);
     setLocation(existingSession.location_name || "");
     setNotes(existingSession.notes || "");
+    setRequiresVerified(!!existingSession.requires_verified);
   }, [isOpen, existingSession]);
 
   const canSubmit = date && time && !saving;
@@ -84,6 +90,7 @@ export default function ScheduleSessionSheet({
       duration_minutes: duration,
       location_name: location || null,
       notes: notes || null,
+      requires_verified: hostIsVerified ? requiresVerified : false,
     };
 
     const result = isEdit
@@ -113,6 +120,7 @@ export default function ScheduleSessionSheet({
     setDuration(120);
     setLocation(defaultLocation);
     setNotes("");
+    setRequiresVerified(false);
     setSaving(false);
     setSuccess(false);
     setConfirmOvernight(false);
@@ -314,6 +322,31 @@ export default function ScheduleSessionSheet({
                   "
                 />
               </div>
+
+              {hostIsVerified && (
+                <div className="mb-6 bg-white border border-cream-dark rounded-xl p-3">
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={requiresVerified}
+                      onChange={(e) => setRequiresVerified(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 accent-sage cursor-pointer"
+                    />
+                    <span className="flex-1">
+                      <span className="text-sm font-medium text-charcoal flex items-center gap-1">
+                        Verified parents only
+                        <svg width="12" height="12" viewBox="0 0 20 20" fill="none">
+                          <path d="M10 1l2.5 2 3 -.5 .5 3 2 2.5 -2 2.5 -.5 3 -3 -.5 -2.5 2 -2.5 -2 -3 .5 -.5 -3 -2 -2.5 2 -2.5 .5 -3 3 .5z" fill="#5C6B52" />
+                          <path d="M7 10l2 2 4-4" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </span>
+                      <span className="text-xs text-taupe block mt-0.5">
+                        Only parents with the Verified badge can RSVP &ldquo;Going.&rdquo;
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              )}
 
               <Button
                 fullWidth

--- a/frontend/src/components/playgroup/SessionCard.jsx
+++ b/frontend/src/components/playgroup/SessionCard.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import useRsvps from "../../hooks/useRsvps";
+import { useAuth } from "../../context/AuthContext";
 import { friendlyDate, formatSessionTime, formatDuration } from "../../lib/dateUtils";
 import { downloadIcs } from "../../lib/icsExport";
 
@@ -21,10 +22,17 @@ function AddToCalendarButton({ session, playgroupName }) {
 
 function RsvpButtons({ session, playgroupName }) {
   const sessionId = session.id;
+  const { profile } = useAuth();
   const { myRsvp, goingCount, upsertRsvp, deleteRsvp } = useRsvps(sessionId);
   const [saving, setSaving] = useState(false);
 
+  // Verified-only sessions: server enforces via trigger, but we mirror
+  // the check here so the button is disabled with an explanation
+  // instead of failing on click.
+  const verifiedGate = !!session.requires_verified && !profile?.is_verified;
+
   const handleRsvp = async (status) => {
+    if (verifiedGate && status === "going") return;
     setSaving(true);
     if (myRsvp?.status === status) {
       await deleteRsvp();
@@ -38,10 +46,22 @@ function RsvpButtons({ session, playgroupName }) {
   const isNotGoing = myRsvp?.status === "not_going";
 
   return (
-    <div className="flex items-center gap-2 mt-3">
+    <div className="flex flex-col gap-2 mt-3">
+      {session.requires_verified && (
+        <div className="flex items-center gap-1.5 text-[11px] text-sage-dark">
+          <svg width="12" height="12" viewBox="0 0 20 20" fill="none">
+            <path d="M10 1l2.5 2 3 -.5 .5 3 2 2.5 -2 2.5 -.5 3 -3 -.5 -2.5 2 -2.5 -2 -3 .5 -.5 -3 -2 -2.5 2 -2.5 .5 -3 3 .5z" fill="#5C6B52" />
+            <path d="M7 10l2 2 4-4" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="font-medium">Verified parents only</span>
+          {verifiedGate && <span className="text-taupe">— request verification on your profile</span>}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
       <button
         onClick={() => handleRsvp("going")}
-        disabled={saving}
+        disabled={saving || verifiedGate}
+        title={verifiedGate ? "Verified parents only" : undefined}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-150 cursor-pointer border ${
           isGoing
             ? "bg-sage text-white border-sage"
@@ -81,6 +101,7 @@ function RsvpButtons({ session, playgroupName }) {
       </button>
 
       {isGoing && <AddToCalendarButton session={session} playgroupName={playgroupName} />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -1035,6 +1035,7 @@ export default function HostDashboard() {
         onClose={() => setShowScheduleSheet(false)}
         defaultLocation={realPlaygroup?.location_name || ""}
         playgroupName={realPlaygroup?.name || ""}
+        hostIsVerified={!!profile?.is_verified}
         onSchedule={async (sessionData) => {
           const result = await createSession({
             ...sessionData,
@@ -1052,6 +1053,7 @@ export default function HostDashboard() {
         onClose={() => setEditTarget(null)}
         defaultLocation={realPlaygroup?.location_name || ""}
         playgroupName={realPlaygroup?.name || ""}
+        hostIsVerified={!!profile?.is_verified}
         existingSession={editTarget}
         onUpdate={async (updates, prev) => {
           const parts = [];

--- a/supabase/migrations/20260425000012_sessions_requires_verified.sql
+++ b/supabase/migrations/20260425000012_sessions_requires_verified.sql
@@ -1,0 +1,59 @@
+-- Verified-only sessions.
+--
+-- Hosts who have built up a verified reputation sometimes want to
+-- restrict a session to other verified parents — e.g. a small in-home
+-- gathering where they want a stronger trust signal than the default
+-- open RSVP. This adds an opt-in flag on sessions and a trigger that
+-- blocks non-verified parents from RSVPing 'going'.
+--
+-- The flag is enforced server-side (trigger on rsvps) so a hand-rolled
+-- API call can't bypass it. The frontend mirrors the check to disable
+-- the button and explain why.
+
+alter table public.sessions
+  add column if not exists requires_verified boolean not null default false;
+
+create or replace function public.enforce_session_requires_verified()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  needs_verified boolean;
+  is_user_verified boolean;
+begin
+  -- Only block 'going' RSVPs. 'not_going' is fine — letting people
+  -- decline doesn't grant access.
+  if new.status is distinct from 'going' then
+    return new;
+  end if;
+
+  select s.requires_verified
+    into needs_verified
+    from public.sessions s
+    where s.id = new.session_id;
+
+  if not coalesce(needs_verified, false) then
+    return new;
+  end if;
+
+  select coalesce(p.is_verified, false)
+    into is_user_verified
+    from public.profiles p
+    where p.id = new.user_id;
+
+  if not coalesce(is_user_verified, false) then
+    raise exception 'session_requires_verified'
+      using errcode = '42501',
+            hint = 'This session is open to verified parents only.';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists rsvps_enforce_requires_verified on public.rsvps;
+create trigger rsvps_enforce_requires_verified
+  before insert or update of status on public.rsvps
+  for each row execute function public.enforce_session_requires_verified();


### PR DESCRIPTION
## Summary
- New \`sessions.requires_verified\` flag (default false)
- Trigger on rsvps blocks non-verified users from RSVPing 'going'
- Verified hosts get a toggle in the schedule sheet
- SessionCard shows verified-only badge and disables Going for unverified parents

## Test plan
- [ ] Verified host schedules with toggle on → flag persists
- [ ] Unverified parent sees disabled Going button + explanation
- [ ] Verified parent can RSVP normally
- [ ] Unverified host doesn't see the toggle
- [ ] Trigger blocks RSVP at SQL level (curl/PostgREST)