### PR TITLE
PR-S: surface Verified host badge

### DIFF
--- a/frontend/src/components/profile/ProfilePanel.jsx
+++ b/frontend/src/components/profile/ProfilePanel.jsx
@@ -33,6 +33,10 @@ function ChildrenCard({ children }) {
 export default function ProfilePanel({ profile, onMessage }) {
   if (!profile) return null;
   const verified = !!profile.is_phone_verified;
+  // is_verified is the admin-granted "Verified host" badge — distinct
+  // from phone verification. Surfaced as a separate badge so users can
+  // tell the two trust signals apart.
+  const isVerifiedHost = !!profile.is_verified && profile.account_type === "organizer";
   const fullName = `${profile.first_name ?? ""} ${profile.last_name ?? ""}`.trim();
 
   return (
@@ -52,8 +56,23 @@ export default function ProfilePanel({ profile, onMessage }) {
             <VerifiedBadge verified={verified} />
           </div>
         </div>
-        <div className="font-bold text-charcoal mt-2">{fullName || "Kiddaboo user"}</div>
+        <div className="font-bold text-charcoal mt-2 flex items-center gap-1.5">
+          {fullName || "Kiddaboo user"}
+          {isVerifiedHost && (
+            <span title="Verified host" className="inline-flex">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <circle cx="8" cy="8" r="7" fill="#7A8F6D" />
+                <path d="M5 8L7 10L11 6" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+          )}
+        </div>
         {verified && <VerifiedLabel accountType={profile.account_type} />}
+        {isVerifiedHost && (
+          <div className="text-xs text-sage-dark font-bold mt-1">
+            ✓ Verified host
+          </div>
+        )}
       </div>
 
       <div className="text-center py-3 border-t border-b border-cream-dark mb-4">

--- a/frontend/src/pages/PlaygroupDetail.jsx
+++ b/frontend/src/pages/PlaygroupDetail.jsx
@@ -68,6 +68,7 @@ function transformRealPlaygroup(pg) {
       isHost: m.role === "creator",
       membership_role: m.role,
       is_phone_verified: m.profiles?.is_phone_verified,
+      is_verified: m.profiles?.is_verified,
       account_type: m.profiles?.account_type,
       zip_code: m.profiles?.zip_code,
       bio: m.profiles?.bio,
@@ -169,7 +170,7 @@ export default function PlaygroupDetail() {
       .select(`
         *,
         profiles:creator_id ( first_name, last_name, bio, philosophy_tags, is_verified, trust_score ),
-        memberships ( user_id, role, profiles:user_id ( first_name, last_name, is_phone_verified, bio, philosophy_tags, account_type, zip_code, photo_url ) )
+        memberships ( user_id, role, profiles:user_id ( first_name, last_name, is_phone_verified, is_verified, bio, philosophy_tags, account_type, zip_code, photo_url ) )
       `)
       .eq("id", id)
       .single();
@@ -637,6 +638,14 @@ export default function PlaygroupDetail() {
                           {m.first_name} {m.last_name}
                         </div>
                         <RoleBadge role={isOrganizer ? "organizer" : "parent"} />
+                        {isOrganizer && m.is_verified && (
+                          <span title="Verified host" className="inline-flex">
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                              <circle cx="8" cy="8" r="7" fill="#7A8F6D" />
+                              <path d="M5 8L7 10L11 6" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          </span>
+                        )}
                       </div>
                       <div className="text-[11px] text-taupe">
                         {isOrganizer ? "Runs the group" : ""}


### PR DESCRIPTION
## Summary
- Members list in PlaygroupDetail shows a verified-host checkmark next to organizer names
- ProfilePanel shows the badge inline + a "Verified host" line for organizers with is_verified
- PlaygroupDetail member fetch now includes is_verified

## Test plan
- [ ] As parent, view a verified host's playgroup → host row shows checkmark
- [ ] Tap the host → ProfilePanel shows "Verified host" line
- [ ] Non-verified host renders without badge