### PR TITLE
PR-T: fix reviewer photo in reviews

### DIFF
--- a/frontend/src/components/playgroup/ReviewCard.jsx
+++ b/frontend/src/components/playgroup/ReviewCard.jsx
@@ -4,7 +4,7 @@ export default function ReviewCard({ review, isOwn, onEdit, onReport }) {
   // Support both old shape (mock) and new shape (real)
   const name = review.reviewer_name || review.reviewer || "User";
   const initials = review.reviewer_initials || review.initials || "U";
-  const avatarUrl = review.reviewer_avatar_url || review.avatar_url || null;
+  const avatarUrl = review.reviewer_photo_url || review.avatar_url || null;
   const overall = review.rating_environment
     ? Math.round(
         (review.rating_environment +

--- a/frontend/src/hooks/useReviews.js
+++ b/frontend/src/hooks/useReviews.js
@@ -14,7 +14,7 @@ export default function useReviews(playgroupId) {
       .from("reviews")
       .select(`
         *,
-        profiles:reviewer_id ( first_name, last_name, avatar_url )
+        profiles:reviewer_id ( first_name, last_name, photo_url )
       `)
       .eq("playgroup_id", playgroupId)
       .order("created_at", { ascending: false });
@@ -29,7 +29,7 @@ export default function useReviews(playgroupId) {
             reviewer_name: `${first} ${last}`.trim(),
             reviewer_initials:
               (first[0] || "U").toUpperCase() + (last[0] || "").toUpperCase(),
-            reviewer_avatar_url: r.profiles?.avatar_url || null,
+            reviewer_photo_url: r.profiles?.photo_url || null,
           };
         })
       );
@@ -144,7 +144,7 @@ export default function useReviews(playgroupId) {
         })
         .select(`
           *,
-          profiles:reviewer_id ( first_name, last_name, avatar_url )
+          profiles:reviewer_id ( first_name, last_name, photo_url )
         `)
         .single();
 
@@ -156,7 +156,7 @@ export default function useReviews(playgroupId) {
           reviewer_name: `${first} ${last}`.trim(),
           reviewer_initials:
             (first[0] || "U").toUpperCase() + (last[0] || "").toUpperCase(),
-          reviewer_avatar_url: data.profiles?.avatar_url || null,
+          reviewer_photo_url: data.profiles?.photo_url || null,
         };
         setReviews((prev) => [enriched, ...prev]);
       }


### PR DESCRIPTION
## Summary
- useReviews now joins on profiles.photo_url (not the non-existent avatar_url)
- Renamed derived field reviewer_avatar_url → reviewer_photo_url
- ReviewCard updated to read the new field name

## Test plan
- [ ] Submit a review on a past session → reviewer photo shows in ReviewCard
- [ ] Initials fallback still works for users without a photo