### PR TITLE
PR-U: client-side profile photo resize

### DIFF
--- a/frontend/src/lib/imageProcessing.js
+++ b/frontend/src/lib/imageProcessing.js
@@ -1,0 +1,53 @@
+// Client-side profile photo processing.
+//
+// Phones routinely produce 3–10 MB JPEGs. Uploading those raw stalls
+// the Save button for seconds on slow connections and bloats Storage.
+// We center-crop to square, downscale to MAX_SIZE, and re-encode as
+// JPEG at QUALITY before handing the file to uploadProfilePhoto.
+//
+// HEIC: Safari can decode HEIC via createImageBitmap but other
+// browsers can't. If decoding throws we fall through to the original
+// file — uploadProfilePhoto's validation accepts HEIC and the server
+// stores it; only the in-browser preview suffers, which is a far
+// smaller problem than refusing the upload.
+
+const MAX_SIZE = 1024;
+const QUALITY = 0.85;
+const PROCESSED_MIME = "image/jpeg";
+
+export async function processProfilePhoto(file) {
+  if (!(file instanceof Blob)) return file;
+
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    return file;
+  }
+
+  try {
+    const side = Math.min(bitmap.width, bitmap.height);
+    const sx = Math.floor((bitmap.width - side) / 2);
+    const sy = Math.floor((bitmap.height - side) / 2);
+    const target = Math.min(side, MAX_SIZE);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = target;
+    canvas.height = target;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, target, target);
+
+    const blob = await new Promise((resolve) =>
+      canvas.toBlob(resolve, PROCESSED_MIME, QUALITY)
+    );
+
+    if (!blob) return file;
+
+    // Re-wrap as File so callers that read .name (e.g. extension parsing
+    // in storage.js) keep working. Always force .jpg since we re-encoded.
+    const baseName = (file.name || "photo").replace(/\.[^.]+$/, "");
+    return new File([blob], `${baseName}.jpg`, { type: PROCESSED_MIME });
+  } finally {
+    bitmap.close?.();
+  }
+}

--- a/frontend/src/pages/CreateProfile.jsx
+++ b/frontend/src/pages/CreateProfile.jsx
@@ -7,6 +7,7 @@ import Button from "../components/ui/Button";
 import { useOnboarding } from "../context/OnboardingContext";
 import { useAuth } from "../context/AuthContext";
 import { uploadProfilePhoto } from "../lib/storage";
+import { processProfilePhoto } from "../lib/imageProcessing";
 import { PHILOSOPHY_TAGS } from "../data/mockData";
 
 export default function CreateProfile() {
@@ -25,13 +26,12 @@ export default function CreateProfile() {
   );
   const isOrganizer = pendingAccountType === "organizer";
 
-  const handlePhotoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setPhotoFile(file);
-      const url = URL.createObjectURL(file);
-      updateField("photoUrl", url);
-    }
+  const handlePhotoChange = async (e) => {
+    const raw = e.target.files?.[0];
+    if (!raw) return;
+    const processed = await processProfilePhoto(raw);
+    setPhotoFile(processed);
+    updateField("photoUrl", URL.createObjectURL(processed));
   };
 
   const handleContinue = async () => {

--- a/frontend/src/pages/EditProfile.jsx
+++ b/frontend/src/pages/EditProfile.jsx
@@ -6,6 +6,7 @@ import Button from "../components/ui/Button";
 import { useAuth } from "../context/AuthContext";
 import { supabase } from "../lib/supabase";
 import { uploadProfilePhoto } from "../lib/storage";
+import { processProfilePhoto } from "../lib/imageProcessing";
 import { PHILOSOPHY_TAGS, AGE_RANGES, PERSONALITY_TAGS } from "../data/mockData";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 
@@ -64,12 +65,16 @@ export default function EditProfile() {
     }
   }, [profile]);
 
-  const handlePhotoChange = (e) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setPhotoFile(file);
-      setPhotoPreview(URL.createObjectURL(file));
-    }
+  const handlePhotoChange = async (e) => {
+    const raw = e.target.files?.[0];
+    if (!raw) return;
+    // Process synchronously before previewing so the preview, the file
+    // we'll upload, and the file we measure size against are all the
+    // same processed blob — no chance of a 4 MB original sneaking past
+    // validation that compared against the resized version.
+    const processed = await processProfilePhoto(raw);
+    setPhotoFile(processed);
+    setPhotoPreview(URL.createObjectURL(processed));
   };
 
   // Fetch children


### PR DESCRIPTION
## Summary
- New helper \`processProfilePhoto\` (Canvas-based, no deps): center-crop square + downscale to 1024px + JPEG @ 0.85
- Wired into CreateProfile + EditProfile photo pickers
- HEIC falls through to original file when the browser can't decode

## Test plan
- [ ] Pick a large iPhone photo (4+ MB) → uploaded blob is ~200-400 KB
- [ ] Non-square photo center-crops correctly
- [ ] HEIC on Safari renders preview; on other browsers falls back without crashing