### PR TITLE
PR-W: host photo on browse cards

### DIFF
--- a/frontend/src/components/browse/PlaygroupCard.jsx
+++ b/frontend/src/components/browse/PlaygroupCard.jsx
@@ -105,8 +105,12 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
             <div className="mt-6 pt-5 border-t border-cream-dark">
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-sage-light flex items-center justify-center">
-                    <span className="text-[10px] font-bold text-sage-dark">{group.hostInitials}</span>
+                  <div className="w-8 h-8 rounded-full bg-sage-light flex items-center justify-center overflow-hidden">
+                    {group.hostPhoto ? (
+                      <img src={group.hostPhoto} alt="" className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="text-[10px] font-bold text-sage-dark">{group.hostInitials}</span>
+                    )}
                   </div>
                   <span className="text-sm font-medium text-charcoal">{group.hostName}</span>
                   {group.verified && (
@@ -239,8 +243,12 @@ export default function PlaygroupCard({ group, onClick, featured = false, premiu
         {/* Footer */}
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
-            <div className="w-6 h-6 rounded-full bg-sage-light flex items-center justify-center">
-              <span className="text-[9px] font-bold text-sage-dark">{group.hostInitials}</span>
+            <div className="w-6 h-6 rounded-full bg-sage-light flex items-center justify-center overflow-hidden">
+              {group.hostPhoto ? (
+                <img src={group.hostPhoto} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-[9px] font-bold text-sage-dark">{group.hostInitials}</span>
+              )}
             </div>
             <span className="text-xs font-medium text-taupe-dark">{group.hostName}</span>
             {group.verified && (

--- a/frontend/src/lib/playgroupTransform.js
+++ b/frontend/src/lib/playgroupTransform.js
@@ -56,6 +56,7 @@ export function transformPlaygroup(pg, index = 0, overrides = {}) {
     setting: pg.environment?.setting || "Indoor",
     hostName: `${hostFirst} ${hostLast}`.trim(),
     hostInitials,
+    hostPhoto: host?.photo_url || overrides.hostPhoto || null,
     verified: host?.is_verified || false,
     photoColor: CARD_COLORS[index % CARD_COLORS.length],
     photos: pg.photos || [],

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -85,7 +85,7 @@ export default function Browse() {
           .from("playgroups")
           .select(`
             *,
-            profiles:creator_id ( first_name, last_name, is_verified ),
+            profiles:creator_id ( first_name, last_name, photo_url, is_verified ),
             memberships ( role )
           `)
           .eq("is_active", true)


### PR DESCRIPTION
## Summary
- Browse query now selects creator photo_url
- transformPlaygroup exposes hostPhoto
- PlaygroupCard renders avatar (featured + compact variants), initials fallback preserved

## Test plan
- [ ] Browse cards show host photo when set
- [ ] Hosts without a photo show initials