### PR TITLE
PR-X: carry photoUrl through join approval

### DIFF
--- a/frontend/src/pages/host/HostDashboard.jsx
+++ b/frontend/src/pages/host/HostDashboard.jsx
@@ -133,6 +133,7 @@ export default function HostDashboard() {
               childrenAges: kids.map((c) => c.age_range ? `${c.name} (${c.age_range})` : c.name),
               philosophyTags: m.profiles?.philosophy_tags || [],
               bio: m.profiles?.bio || "",
+              photoUrl: m.profiles?.photo_url || "",
               answers,
               requestedAt: timeAgo(m.created_at),
               createdAt: m.created_at,
@@ -307,7 +308,7 @@ export default function HostDashboard() {
         childrenAges: request.childrenAges,
         bio: request.bio || "",
         philosophyTags: request.philosophyTags || [],
-        photoUrl: "",
+        photoUrl: request.photoUrl || "",
         joinedAt: new Date(joinedAt).toLocaleDateString("en-US", {
           month: "short",
           year: "numeric",


### PR DESCRIPTION
## Summary
- HostDashboard pending requests now include photoUrl
- handleApprove copies it onto the new member row

## Test plan
- [ ] Approve a join request from a user with a photo → member row shows photo immediately