### PR TITLE
PR-Z: parent-core audit fixes

### DIFF
--- a/frontend/src/components/playgroup/SessionCard.jsx
+++ b/frontend/src/components/playgroup/SessionCard.jsx
@@ -28,8 +28,9 @@ function RsvpButtons({ session, playgroupName }) {
 
   // Verified-only sessions: server enforces via trigger, but we mirror
   // the check here so the button is disabled with an explanation
-  // instead of failing on click.
-  const verifiedGate = !!session.requires_verified && !profile?.is_verified;
+  // instead of failing on click. Treat unloaded profile as not-verified
+  // so we don't briefly enable the button before auth resolves.
+  const verifiedGate = !!session.requires_verified && (!profile || !profile.is_verified);
 
   const handleRsvp = async (status) => {
     if (verifiedGate && status === "going") return;

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -568,7 +568,7 @@ export default function Browse() {
                 <button
                   onClick={() => {
                     setSearch("");
-                    setFilters({ vibeTags: [], ageRange: [], setting: [], accessType: [] });
+                    setFilters({ vibeTags: [], ageRange: [], setting: [], accessType: [], verifiedOnly: false });
                   }}
                   className="text-sm text-sage font-medium hover:text-sage-dark cursor-pointer bg-transparent border-none underline underline-offset-4"
                 >


### PR DESCRIPTION
## Summary
Two small bugs caught in the parent-core audit:

- **Browse [Browse.jsx:571]**: \"Clear all filters\" missed \`verifiedOnly\`. Users would hit Clear, see narrowed results still, and not understand why.
- **SessionCard [SessionCard.jsx:32]**: verified-gate let \`!profile?.is_verified\` evaluate to \`false\` when profile was null mid-load, briefly enabling the Going button on verified-only sessions before re-disabling it. Treats unloaded profile as not-verified.

## Test plan
- [ ] Browse: turn on verified-only + a vibe tag → empty state → Clear → both reset
- [ ] On a verified-only session as an unverified parent: button stays disabled across full page load (no flash of enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)