### PR TITLE
PR-AA: parent-fringe audit fixes

### DIFF
--- a/frontend/src/pages/GroupChat.jsx
+++ b/frontend/src/pages/GroupChat.jsx
@@ -98,7 +98,7 @@ export default function GroupChat() {
     prevMessageCount.current = messages.length;
     // Keep last-read timestamp fresh while viewing
     if (messages.length > 0) markChatRead(playgroupId);
-  }, [messages.length]);
+  }, [messages.length, playgroupId]);
 
   // Handle send. Return the ok flag from sendMessage so ChatInput can
   // keep the typed text in the field on failure (#24) instead of

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -223,7 +223,7 @@ export default function MyProfile() {
             onClick={() => !deleting && setShowDeleteConfirm(false)}
           />
           <div className="fixed inset-0 z-50 flex items-center justify-center px-6">
-            <div className="bg-cream rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="bg-cream rounded-2xl p-6 max-w-sm w-full shadow-xl max-h-[85vh] overflow-y-auto">
               <h3 className="font-heading font-bold text-charcoal text-lg mb-2">
                 Delete your account?
               </h3>

--- a/frontend/src/pages/NotificationSettings.jsx
+++ b/frontend/src/pages/NotificationSettings.jsx
@@ -148,7 +148,7 @@ export default function NotificationSettings() {
   // the error, so a dropped network request would leave the UI in a
   // state that silently disagreed with the DB until the next reload.
   const togglePref = async (key) => {
-    if (!user) return;
+    if (!user || saving) return;
     const previous = prefs;
     const updated = { ...prefs, [key]: !prefs[key] };
     setPrefs(updated);


### PR DESCRIPTION
## Summary
- **NotificationSettings [.jsx:151]**: \`togglePref\` had no \`saving\` guard. Rapid taps could fire overlapping \`profiles.update()\` calls and a slow second response could overwrite the first with stale prefs state.
- **MyProfile [.jsx:226]**: delete confirmation modal could overflow on small phones (no \`max-h\` / \`overflow-y-auto\`). Action buttons could be pushed off-screen.
- **GroupChat [.jsx:101]**: \`markChatRead\` effect missing \`playgroupId\` in deps — navigating between groups left a stale id in the closure, writing the wrong per-group marker.

## Test plan
- [ ] Toggle a notification pref rapidly 5x → final state matches DB, no toggle stuck mid-flight
- [ ] Open delete account modal on a small phone (or shrink window) → list scrolls, buttons stay visible
- [ ] Navigate Group A → Group B → confirm last-read marker tracks the current group, not Group A

🤖 Generated with [Claude Code](https://claude.com/claude-code)