### PR TITLE
PR-AB: surface schedule/update errors

### DIFF
--- a/frontend/src/components/host/ScheduleSessionSheet.jsx
+++ b/frontend/src/components/host/ScheduleSessionSheet.jsx
@@ -48,6 +48,7 @@ export default function ScheduleSessionSheet({
   const [requiresVerified, setRequiresVerified] = useState(false);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [submitError, setSubmitError] = useState("");
   const [confirmOvernight, setConfirmOvernight] = useState(false);
 
   // Prefill when opening in edit mode. Guarded on isOpen so the form
@@ -83,6 +84,7 @@ export default function ScheduleSessionSheet({
 
   const submit = async () => {
     setSaving(true);
+    setSubmitError("");
 
     const scheduledAt = new Date(`${date}T${time}:00`).toISOString();
     const payload = {
@@ -98,7 +100,14 @@ export default function ScheduleSessionSheet({
       : await onSchedule?.({ title: playgroupName || "Playdate", ...payload });
 
     setSaving(false);
-    if (!result?.error) setSuccess(true);
+    if (result?.error) {
+      setSubmitError(
+        result.error.message ||
+          `Couldn't ${isEdit ? "update" : "schedule"} the session. Please try again.`,
+      );
+      return;
+    }
+    setSuccess(true);
   };
 
   const handleSchedule = async () => {
@@ -123,6 +132,7 @@ export default function ScheduleSessionSheet({
     setRequiresVerified(false);
     setSaving(false);
     setSuccess(false);
+    setSubmitError("");
     setConfirmOvernight(false);
     onClose();
   };
@@ -345,6 +355,12 @@ export default function ScheduleSessionSheet({
                       </span>
                     </span>
                   </label>
+                </div>
+              )}
+
+              {submitError && (
+                <div className="bg-terracotta-light/30 border border-terracotta-light rounded-xl p-3 mb-3">
+                  <p className="text-sm text-terracotta font-medium">{submitError}</p>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
\`ScheduleSessionSheet\` checked \`result?.error\` but never displayed it. On a failed \`createSession\`/\`updateSession\` the sheet cleared \`saving\`, skipped \`success\`, and sat there with no feedback — host had no idea their submit didn't land.

Adds a \`submitError\` state, surfaces \`result.error.message\` in a terracotta banner above the submit button, clears it on retry and on close. Mirrors \`CancelSessionSheet\` error handling.

This was the only real bug found in the host audit. All other host flows are solid.

## Test plan
- [ ] Schedule a session with the network throttled to fail → error banner appears, sheet stays open with values intact, retry works once network is back
- [ ] Edit a session same way → same behavior
- [ ] Closing the sheet after an error and reopening → no stale error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)