### PR TITLE
PR-AD: discovery polish — distance filter, Newest sort, smart empty

### DIFF
--- a/frontend/src/components/browse/FilterSheet.jsx
+++ b/frontend/src/components/browse/FilterSheet.jsx
@@ -41,7 +41,14 @@ function ChipGroup({ label, options, selected, onToggle }) {
   );
 }
 
-export default function FilterSheet({ open, onClose, filters, onChange, isPremium = false, onUpgrade }) {
+const DISTANCE_OPTIONS = [
+  { value: 5, label: "≤ 5 mi" },
+  { value: 10, label: "≤ 10 mi" },
+  { value: 25, label: "≤ 25 mi" },
+  { value: 50, label: "≤ 50 mi" },
+];
+
+export default function FilterSheet({ open, onClose, filters, onChange, isPremium = false, onUpgrade, hasLocation = false }) {
   if (!open) return null;
 
   const toggle = (key, value) => {
@@ -57,7 +64,8 @@ export default function FilterSheet({ open, onClose, filters, onChange, isPremiu
     (filters.ageRange?.length || 0) +
     (filters.setting?.length || 0) +
     (filters.accessType?.length || 0) +
-    (filters.verifiedOnly ? 1 : 0);
+    (filters.verifiedOnly ? 1 : 0) +
+    (filters.maxDistance ? 1 : 0);
 
   const clearAll = () => {
     onChange({
@@ -66,6 +74,15 @@ export default function FilterSheet({ open, onClose, filters, onChange, isPremiu
       setting: [],
       accessType: [],
       verifiedOnly: false,
+      maxDistance: null,
+    });
+  };
+
+  const setMaxDistance = (value) => {
+    // Single-select: tapping the active chip clears it.
+    onChange({
+      ...filters,
+      maxDistance: filters.maxDistance === value ? null : value,
     });
   };
 
@@ -119,6 +136,40 @@ export default function FilterSheet({ open, onClose, filters, onChange, isPremiu
           </div>
 
           <div className="flex flex-col gap-6">
+            {/* Distance — needs user location to be meaningful */}
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-charcoal">Distance</label>
+              {hasLocation ? (
+                <div className="flex flex-wrap gap-2">
+                  {DISTANCE_OPTIONS.map((opt) => {
+                    const isSelected = filters.maxDistance === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setMaxDistance(opt.value)}
+                        className={`
+                          px-3 py-2 rounded-full text-xs font-medium
+                          transition-all duration-150 cursor-pointer border
+                          ${
+                            isSelected
+                              ? "bg-sage-light text-sage-dark border-sage"
+                              : "bg-cream-dark text-taupe border-transparent hover:border-sage-light"
+                          }
+                        `}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-xs text-taupe/70 bg-cream-dark/60 rounded-xl px-3 py-2.5">
+                  Enable location on the Browse page to filter by distance.
+                </p>
+              )}
+            </div>
+
             {/* Vibe */}
             <ChipGroup
               label="Vibe"

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -13,6 +13,7 @@ import { useDocumentTitle } from "../hooks/useDocumentTitle";
 const SORT_OPTIONS = [
   { value: "distance", label: "Nearest" },
   { value: "rating", label: "Rated" },
+  { value: "newest", label: "Newest" },
   { value: "spots", label: "Spots" },
 ];
 
@@ -37,6 +38,7 @@ export default function Browse() {
     setting: [],
     accessType: [],
     verifiedOnly: false,
+    maxDistance: null,
   });
 
   const { userLocation, loading: locationLoading, error: locationError, requestLocation } = useUserLocation();
@@ -138,7 +140,8 @@ export default function Browse() {
     filters.ageRange.length +
     filters.setting.length +
     filters.accessType.length +
-    (filters.verifiedOnly ? 1 : 0);
+    (filters.verifiedOnly ? 1 : 0) +
+    (filters.maxDistance ? 1 : 0);
 
   // Tag and (for free users) gate newly-posted groups. Computed in the
   // memo so the cutoff stays fresh as time passes between fetches.
@@ -218,6 +221,15 @@ export default function Browse() {
       }));
     }
 
+    // Max-distance filter — only applies when we know the user's
+    // location. Groups without coordinates are dropped from a distance
+    // filter rather than silently passing through.
+    if (filters.maxDistance && userLocation) {
+      list = list.filter(
+        (g) => g.distance != null && g.distance <= filters.maxDistance
+      );
+    }
+
     // Sort
     if (sortBy === "distance" && userLocation) {
       // #22: strict distance sort. We used to bucket Open groups above
@@ -237,6 +249,12 @@ export default function Browse() {
       });
     } else if (sortBy === "rating") {
       list.sort((a, b) => b.rating - a.rating);
+    } else if (sortBy === "newest") {
+      list.sort((a, b) => {
+        const at = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const bt = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return bt - at;
+      });
     } else if (sortBy === "reviews") {
       list.sort((a, b) => b.reviewCount - a.reviewCount);
     } else if (sortBy === "spots") {
@@ -563,12 +581,21 @@ export default function Browse() {
                   No playgroups found
                 </h3>
                 <p className="text-sm text-taupe mb-4">
-                  Try adjusting your search or filters.
+                  {(() => {
+                    // Suggest loosening the single most-restrictive
+                    // filter rather than always blanket "clear all", so
+                    // the user keeps the rest of their refinement.
+                    if (search) return "Try a different search term, or loosen your filters.";
+                    if (filters.maxDistance) return "Try a wider distance.";
+                    if (filters.verifiedOnly) return "Try removing 'Verified hosts only'.";
+                    if (filters.accessType.length > 0) return "Try removing access-type filters.";
+                    return "Try adjusting your filters.";
+                  })()}
                 </p>
                 <button
                   onClick={() => {
                     setSearch("");
-                    setFilters({ vibeTags: [], ageRange: [], setting: [], accessType: [], verifiedOnly: false });
+                    setFilters({ vibeTags: [], ageRange: [], setting: [], accessType: [], verifiedOnly: false, maxDistance: null });
                   }}
                   className="text-sm text-sage font-medium hover:text-sage-dark cursor-pointer bg-transparent border-none underline underline-offset-4"
                 >
@@ -607,6 +634,7 @@ export default function Browse() {
         onChange={setFilters}
         isPremium={isPremium}
         onUpgrade={() => navigate("/premium")}
+        hasLocation={!!userLocation}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Distance filter chips (≤5/10/25/50 mi) in FilterSheet, gated on user location
- Newest sort option (created_at desc)
- Smarter empty state — suggests loosening the single most-restrictive filter instead of always blanket clear

## Test plan
- [ ] Grant location → Filters → distance chips render → pick ≤5 mi → far groups disappear
- [ ] Deny location → distance chips replaced with hint text
- [ ] Sort: Newest → freshest groups first
- [ ] Apply only \"Verified hosts only\" with no matches → empty state suggests removing it
- [ ] Clear all resets distance back to Any

🤖 Generated with [Claude Code](https://claude.com/claude-code)