### PR TITLE
PR-AE: onboarding polish — step caption + child-add copy

### DIFF
--- a/frontend/src/components/ui/ProgressBar.jsx
+++ b/frontend/src/components/ui/ProgressBar.jsx
@@ -2,11 +2,18 @@ export default function ProgressBar({ currentStep, totalSteps }) {
   const percent = (currentStep / totalSteps) * 100;
 
   return (
-    <div className="w-full h-1 bg-cream-dark">
-      <div
-        className="h-full bg-sage rounded-r-full transition-all duration-500 ease-out"
-        style={{ width: `${percent}%` }}
-      />
+    <div className="w-full bg-cream">
+      <div className="max-w-md mx-auto px-6 pt-3 pb-1.5">
+        <p className="text-[11px] text-taupe/70 font-medium tracking-wider uppercase">
+          Step {currentStep} of {totalSteps}
+        </p>
+      </div>
+      <div className="w-full h-1 bg-cream-dark">
+        <div
+          className="h-full bg-sage rounded-r-full transition-all duration-500 ease-out"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/AddChildren.jsx
+++ b/frontend/src/pages/AddChildren.jsx
@@ -128,11 +128,17 @@ export default function AddChildren() {
 
         {/* Add another child */}
         <Button variant="secondary" fullWidth onClick={addChild}>
-          + Add another child
+          {data.children.length === 0 ? "+ Add a child" : "+ Add another child"}
         </Button>
 
         {error && (
           <p className="text-sm text-red-500">{error}</p>
+        )}
+
+        {!data.children.some((c) => c.name.trim()) && (
+          <p className="text-xs text-taupe/70 text-center -mb-2">
+            Add at least one name to continue.
+          </p>
         )}
 
         <Button


### PR DESCRIPTION
## Summary
- ProgressBar shows \"Step X of Y\" caption so users know position, not just fill
- AddChildren button label adapts (\"+ Add a child\" → \"+ Add another child\")
- AddChildren disabled hint: \"Add at least one name to continue\" instead of silent disable

## Test plan
- [ ] Walk parent flow (PhoneVerify → CreateProfile → AddChildren) — caption reads 1/4, 2/4, 3/4
- [ ] Walk host flow (CreatePlaygroup → Screening → Environment → Photos) — caption reads 1/5..4/5
- [ ] AddChildren empty state shows \"+ Add a child\" button
- [ ] AddChildren with names typed → microcopy disappears, Continue enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)