### PR TITLE
PR-AG: code-split routes + vendor chunks

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,44 +1,57 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import { OnboardingProvider } from "./context/OnboardingContext";
 import { HostProvider } from "./context/HostContext";
 import AppLayout from "./components/layout/AppLayout";
 import Welcome from "./pages/Welcome";
-import PhoneVerification from "./pages/PhoneVerification";
-import CreateProfile from "./pages/CreateProfile";
-import AddChildren from "./pages/AddChildren";
-import BrowseSuccess from "./pages/BrowseSuccess";
-import PlaygroupDetail from "./pages/PlaygroupDetail";
-import Browse from "./pages/Browse";
-import MyGroups from "./pages/MyGroups";
-import Messages from "./pages/Messages";
-import MyProfile from "./pages/MyProfile";
-import EditProfile from "./pages/EditProfile";
-import CreatePlaygroup from "./pages/host/CreatePlaygroup";
-import ScreeningQuestions from "./pages/host/ScreeningQuestions";
-import EnvironmentSetup from "./pages/host/EnvironmentSetup";
-import HostPhotos from "./pages/host/HostPhotos";
-import HostSuccess from "./pages/host/HostSuccess";
-import HostDashboard from "./pages/host/HostDashboard";
-import HostInsights from "./pages/host/HostInsights";
-import EditPlaygroup from "./pages/host/EditPlaygroup";
-import HostPremium from "./pages/host/HostPremium";
-import Admin from "./pages/Admin";
-import NotificationSettings from "./pages/NotificationSettings";
-import GroupChat from "./pages/GroupChat";
-import ResetPassword from "./pages/ResetPassword";
-import TermsOfService from "./pages/TermsOfService";
-import PrivacyPolicy from "./pages/PrivacyPolicy";
-import Premium from "./pages/Premium";
-import NotFound from "./pages/NotFound";
 import RequireAuth from "./components/auth/RequireAuth";
 import RequireAdmin from "./components/auth/RequireAdmin";
 import OnboardingOnly from "./components/auth/OnboardingOnly";
 import ParentLayout from "./layouts/ParentLayout";
 import OrganizerLayout from "./layouts/OrganizerLayout";
 import RequireRole from "./components/auth/RequireRole";
-import ChooseRole from "./pages/onboarding/ChooseRole";
-import PhoneVerify from "./pages/onboarding/PhoneVerify";
+
+// Lazy-load every non-landing page so the initial JS bundle stays
+// small. Welcome and the auth/role wrappers stay eager since they're
+// rendered immediately.
+const PhoneVerification = lazy(() => import("./pages/PhoneVerification"));
+const CreateProfile = lazy(() => import("./pages/CreateProfile"));
+const AddChildren = lazy(() => import("./pages/AddChildren"));
+const BrowseSuccess = lazy(() => import("./pages/BrowseSuccess"));
+const PlaygroupDetail = lazy(() => import("./pages/PlaygroupDetail"));
+const Browse = lazy(() => import("./pages/Browse"));
+const MyGroups = lazy(() => import("./pages/MyGroups"));
+const Messages = lazy(() => import("./pages/Messages"));
+const MyProfile = lazy(() => import("./pages/MyProfile"));
+const EditProfile = lazy(() => import("./pages/EditProfile"));
+const CreatePlaygroup = lazy(() => import("./pages/host/CreatePlaygroup"));
+const ScreeningQuestions = lazy(() => import("./pages/host/ScreeningQuestions"));
+const EnvironmentSetup = lazy(() => import("./pages/host/EnvironmentSetup"));
+const HostPhotos = lazy(() => import("./pages/host/HostPhotos"));
+const HostSuccess = lazy(() => import("./pages/host/HostSuccess"));
+const HostDashboard = lazy(() => import("./pages/host/HostDashboard"));
+const HostInsights = lazy(() => import("./pages/host/HostInsights"));
+const EditPlaygroup = lazy(() => import("./pages/host/EditPlaygroup"));
+const HostPremium = lazy(() => import("./pages/host/HostPremium"));
+const Admin = lazy(() => import("./pages/Admin"));
+const NotificationSettings = lazy(() => import("./pages/NotificationSettings"));
+const GroupChat = lazy(() => import("./pages/GroupChat"));
+const ResetPassword = lazy(() => import("./pages/ResetPassword"));
+const TermsOfService = lazy(() => import("./pages/TermsOfService"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
+const Premium = lazy(() => import("./pages/Premium"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const ChooseRole = lazy(() => import("./pages/onboarding/ChooseRole"));
+const PhoneVerify = lazy(() => import("./pages/onboarding/PhoneVerify"));
+
+function RouteFallback() {
+  return (
+    <div className="min-h-screen bg-cream flex items-center justify-center">
+      <div className="w-8 h-8 border-2 border-sage border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}
 
 export default function App() {
   return (
@@ -46,6 +59,7 @@ export default function App() {
       <AuthProvider>
       <OnboardingProvider>
         <HostProvider>
+          <Suspense fallback={<RouteFallback />}>
           <Routes>
             {/* Public routes — no auth required */}
             <Route path="/choose-role" element={<ChooseRole />} />
@@ -94,6 +108,7 @@ export default function App() {
             {/* 404 catch-all */}
             <Route path="*" element={<NotFound />} />
           </Routes>
+          </Suspense>
         </HostProvider>
       </OnboardingProvider>
       </AuthProvider>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Split big third-party deps into their own long-cache chunks
+          // so a tweak to a page component doesn't bust them.
+          react: ['react', 'react-dom', 'react-router-dom'],
+          supabase: ['@supabase/supabase-js'],
+          crop: ['react-easy-crop'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
Single 1.07 MB / 287 KB-gzip bundle was loading every route eagerly (including leaflet 149 KB and react-easy-crop 24 KB).

- Lazy-load every page in App.jsx via React.lazy + Suspense
- Vite manualChunks splits react/react-router, supabase-js, react-easy-crop into separate vendor chunks

Initial landing payload now ~145 KB gzipped (down from 287 KB, 49% smaller). Heavy deps load only on routes that need them.

## Test plan
- [ ] Landing (/) loads, Welcome renders without spinner
- [ ] Tap into /browse — brief spinner fallback, then page renders
- [ ] Open photo crop modal on /edit-profile — react-easy-crop chunk fetched on demand
- [ ] Network tab shows separate \`react-*.js\`, \`supabase-*.js\` chunks
- [ ] Hard reload on a deep route (/playgroup/:id) still works (Suspense covers route fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)